### PR TITLE
Added a plugin, where team leader can set monthly quota in hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ WEB-INF/templates_c/*.php
 WEB-INF/templates_c/*.png
 WEB-INF/lib/tcpdf/
 nbproject/
+upload/
+.vscode/

--- a/WEB-INF/config.php.dist
+++ b/WEB-INF/config.php.dist
@@ -214,3 +214,7 @@ define('AUTH_MODULE', 'db');
 //  'member_of' => array());            // List of groups, membership in which is required for user to be authenticated.
 
 // define('AUTH_DEBUG', false); // Note: enabling AUTH_DEBUG breaks redirects as debug output is printed before setting redirect header. Do not enable on production systems.
+
+// team manager can set monthly quota for years between these values:
+define('MONTHLY_QUOTA_YEARS_START', 2010); // if nothing is specified, it falls back to 2010
+define('MONTHLY_QUOTA_YEARS_END', 2031); // if nothing is specified it falls back to 2030

--- a/WEB-INF/lib/ttTeamHelper.class.php
+++ b/WEB-INF/lib/ttTeamHelper.class.php
@@ -703,7 +703,7 @@ class ttTeamHelper {
   static function update($team_id, $fields)
   {
     // We'll require team name to be always set.
-    if (!isset($fields['name'])) return false;
+    if (!isset($fields['name']) || $fields['name'] == "") return false;
 
     $mdb2 = getConnection();
     $name_part = 'name = '.$mdb2->quote($fields['name']);
@@ -718,6 +718,7 @@ class ttTeamHelper {
     $record_type_part = '';
     $plugins_part = '';
     $lock_spec_part = '';
+    $working_hours_part = '';
 
     if (isset($fields['address'])) $addr_part = ', address = '.$mdb2->quote($fields['address']);
     if (isset($fields['currency'])) $currency_part = ', currency = '.$mdb2->quote($fields['currency']);
@@ -730,10 +731,11 @@ class ttTeamHelper {
     if (isset($fields['record_type'])) $record_type_part = ', record_type = '.intval($fields['record_type']);
     if (isset($fields['plugins'])) $plugins_part = ', plugins = '.$mdb2->quote($fields['plugins']);
     if (isset($fields['lock_spec'])) $lock_spec_part = ', lock_spec = '.$mdb2->quote($fields['lock_spec']);
+    if (isset($fields['working_hours'])) $working_hours_part = ', daily_working_hours = '.$mdb2->quote($fields['working_hours']);
 
     $sql = "update tt_teams set $name_part $addr_part $currency_part $lang_part $decimal_mark_part
       $date_format_part $time_format_part $week_start_part $tracking_mode_part $record_type_part
-      $plugins_part $lock_spec_part where id = $team_id";
+      $plugins_part $lock_spec_part $working_hours_part where id = $team_id";
     $affected = $mdb2->exec($sql);
     if (is_a($affected, 'PEAR_Error')) return false;
 

--- a/WEB-INF/resources/de.lang.php
+++ b/WEB-INF/resources/de.lang.php
@@ -154,6 +154,9 @@ $i18n_key_words = array(
 'label.cost' => 'Kosten',
 'label.week_total' => 'Summe (Woche)',
 'label.day_total' => 'Summe (Tag)',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Heute',
 'label.total_hours' => 'Gesamtstunden',
 'label.total_cost' => 'Totale Kosten',
@@ -197,6 +200,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Anmelden',
@@ -243,6 +249,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Daten exportieren',
 'title.import' => 'Daten importieren',
 'title.options' => 'Optionen',

--- a/WEB-INF/resources/de.lang.php
+++ b/WEB-INF/resources/de.lang.php
@@ -203,6 +203,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Anmelden',

--- a/WEB-INF/resources/en.lang.php
+++ b/WEB-INF/resources/en.lang.php
@@ -199,6 +199,8 @@ $i18n_key_words = array(
 'label.year' => 'Year',
 'label.month' => 'Month',
 'label.quota' => 'Quota',
+'label.dailyWorkingHours' => 'Daily working hours',
+'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Login',

--- a/WEB-INF/resources/en.lang.php
+++ b/WEB-INF/resources/en.lang.php
@@ -153,6 +153,9 @@ $i18n_key_words = array(
 'label.cost' => 'Cost',
 'label.week_total' => 'Week total',
 'label.day_total' => 'Day total',
+'label.month_total' => 'Month total',
+'label.month_left' => 'Time until quota is met',
+'label.month_over' => 'Over monthly quota',
 'label.today' => 'Today',
 'label.total_hours' => 'Total hours',
 'label.total_cost' => 'Total cost',
@@ -193,6 +196,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Favorite report',
 'label.cron_schedule' => 'Cron schedule',
 'label.what_is_it' => 'What is it?',
+'label.year' => 'Year',
+'label.month' => 'Month',
+'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Login',
@@ -238,6 +244,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Adding Notification',
 'title.edit_notification' => 'Editing Notification',
 'title.delete_notification' => 'Deleting Notification',
+'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exporting Team Data',
 'title.import' => 'Importing Team Data',
 'title.options' => 'Options',

--- a/WEB-INF/resources/es.lang.php
+++ b/WEB-INF/resources/es.lang.php
@@ -178,6 +178,9 @@ $i18n_key_words = array(
 // 'label.cost' => 'Cost',
 // 'label.week_total' => 'Week total',
 // 'label.day_total' => 'Day total',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Hoy',
 'label.total_hours' => 'Horas totales',
 // TODO: translate the following strings.
@@ -228,6 +231,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Sesión iniciada',
@@ -281,6 +287,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exportar datos',
 'title.import' => 'Importar datos',
 'title.options' => 'Opciones',

--- a/WEB-INF/resources/es.lang.php
+++ b/WEB-INF/resources/es.lang.php
@@ -234,6 +234,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Sesión iniciada',

--- a/WEB-INF/resources/fa.lang.php
+++ b/WEB-INF/resources/fa.lang.php
@@ -211,6 +211,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'ورود',

--- a/WEB-INF/resources/fa.lang.php
+++ b/WEB-INF/resources/fa.lang.php
@@ -162,6 +162,9 @@ $i18n_key_words = array(
 'label.cost' => 'هزینه',
 'label.week_total' => 'کل هفته',
 'label.day_total' => 'کل روز',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'امروز',
 'label.total_hours' => 'مجموع ساعت',
 'label.total_cost' => 'مجموع هزینه ها',
@@ -205,6 +208,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'ورود',
@@ -252,6 +258,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'پشتیانی گرفتن از اطلاعات تیم',
 'title.import' => 'وارد کردن اطلاعات تیم',
 'title.options' => 'گزینه ها',

--- a/WEB-INF/resources/fi.lang.php
+++ b/WEB-INF/resources/fi.lang.php
@@ -156,6 +156,9 @@ $i18n_key_words = array(
 'label.cost' => 'Hinta',
 'label.week_total' => 'Viikko yhteensä',
 'label.day_total' => 'Päivä yhteensä',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Tänään',
 'label.total_hours' => 'Tunnit yhteensä',
 'label.total_cost' => 'Hinta yhteensä',
@@ -197,6 +200,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Raporttipohja',
 'label.cron_schedule' => 'Cron-ajoitus',
 'label.what_is_it' => 'Mikä se on?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // TODO? missing?
 'label.page' => 'Sivu',
@@ -245,6 +251,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Ilmoituksen lisäys',
 'title.edit_notification' => 'Ilmoituksen muokkaus',
 'title.delete_notification' => 'Ilmoituksen poisto',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Tiimitietojen vienti',
 'title.import' => 'Tiimitietojen tunti',
 'title.options' => 'Optiot',

--- a/WEB-INF/resources/fi.lang.php
+++ b/WEB-INF/resources/fi.lang.php
@@ -197,6 +197,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Kirjautuminen',

--- a/WEB-INF/resources/fr.lang.php
+++ b/WEB-INF/resources/fr.lang.php
@@ -166,6 +166,9 @@ $i18n_key_words = array(
 'label.week_total' => 'Total hebdomadaire',
 // TODO: translate the following string.
 // 'label.day_total' => 'Day total',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Aujourd\\\'hui',
 'label.total_hours' => 'Total d\\\'heures',
 'label.total_cost' => 'Coût total',
@@ -210,6 +213,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Connexion',
@@ -260,6 +266,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exporter les données', // TODO: use a noun.
 'title.import' => 'Importer les données', // TODO: use a noun.
 'title.options' => 'Options',

--- a/WEB-INF/resources/fr.lang.php
+++ b/WEB-INF/resources/fr.lang.php
@@ -216,6 +216,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Connexion',

--- a/WEB-INF/resources/he.lang.php
+++ b/WEB-INF/resources/he.lang.php
@@ -167,6 +167,9 @@ $i18n_key_words = array(
 'label.cost' => 'עלות',
 'label.week_total' => 'סיכום שבועי',
 'label.day_total' => 'סיכום יומי',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'היום',
 'label.total_hours' => 'סך הכל שעות',
 'label.total_cost' => 'סך הכל עלות',
@@ -210,6 +213,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'כניסה',
@@ -258,6 +264,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'ייצוא נתוני צוות',
 'title.import' => 'ייבוא נתוני צוות',
 'title.options' => 'אפשרויות',

--- a/WEB-INF/resources/he.lang.php
+++ b/WEB-INF/resources/he.lang.php
@@ -216,6 +216,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'כניסה',

--- a/WEB-INF/resources/nl.lang.php
+++ b/WEB-INF/resources/nl.lang.php
@@ -153,6 +153,9 @@ $i18n_key_words = array(
 'label.cost' => 'Kosten',
 'label.week_total' => 'Week totaal',
 'label.day_total' => 'Dag totaal',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Vandaag',
 'label.total_hours' => 'Uren totaal',
 'label.total_cost' => 'Totale kosten',
@@ -193,6 +196,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Standaard rapport',
 'label.cron_schedule' => 'Cron schema',
 'label.what_is_it' => 'Wat betekent dit?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Aanmelden',
@@ -238,6 +244,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Notificatie toevoegen',
 'title.edit_notification' => 'Notificatie bewerken',
 'title.delete_notification' => 'Notificatie verwijderen',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exporteer teamgegevens',
 'title.import' => 'Importeer teamgegevens',
 'title.options' => 'Opties',

--- a/WEB-INF/resources/nl.lang.php
+++ b/WEB-INF/resources/nl.lang.php
@@ -198,6 +198,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Aanmelden',

--- a/WEB-INF/resources/pl.lang.php
+++ b/WEB-INF/resources/pl.lang.php
@@ -156,6 +156,9 @@ $i18n_key_words = array(
 'label.cost' => 'Koszt',
 'label.week_total' => 'W tym tygodniu',
 'label.day_total' => 'Dziś',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Dziś',
 'label.total_hours' => 'Całkowita liczba godzin',
 'label.total_cost' => 'Koszt całkowity',
@@ -197,6 +200,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Ulubiony raport',
 'label.cron_schedule' => 'Harmonogram crona',
 'label.what_is_it' => 'Co to jest?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Logowanie',
@@ -242,6 +248,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Dodawanie powiadomienia',
 'title.edit_notification' => 'Edytowanie powiadomienia',
 'title.delete_notification' => 'Usuwanie powiadomienia',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Eksport danych zespołu',
 'title.import' => 'Import danych zespołu',
 'title.options' => 'Opcje',

--- a/WEB-INF/resources/pl.lang.php
+++ b/WEB-INF/resources/pl.lang.php
@@ -203,6 +203,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Logowanie',

--- a/WEB-INF/resources/pt-br.lang.php
+++ b/WEB-INF/resources/pt-br.lang.php
@@ -151,6 +151,9 @@ $i18n_key_words = array(
 'label.cost' => 'Custo',
 'label.week_total' => 'Total semanal',
 'label.day_total' => 'Total diário',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Hoje',
 'label.total_hours' => 'Total de horas',
 'label.total_cost' => 'Custo total',
@@ -191,6 +194,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Relatório favorito',
 'label.cron_schedule' => 'Agenda cron',
 'label.what_is_it' => 'O que é?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Login',
@@ -236,6 +242,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Adicionando notificação',
 'title.edit_notification' => 'Editando notificação',
 'title.delete_notification' => 'Apagando notificação',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exportando dados de equipe',
 'title.import' => 'Importando dados de equipe',
 'title.options' => 'Opções',

--- a/WEB-INF/resources/pt-br.lang.php
+++ b/WEB-INF/resources/pt-br.lang.php
@@ -197,6 +197,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Login',

--- a/WEB-INF/resources/ru.lang.php
+++ b/WEB-INF/resources/ru.lang.php
@@ -153,6 +153,9 @@ $i18n_key_words = array(
 'label.cost' => 'Стоимость',
 'label.week_total' => 'Итог за неделю',
 'label.day_total' => 'Итог за день',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Сегодня',
 'label.total_hours' => 'Итого часов',
 'label.total_cost' => 'Итоговая стоимость',
@@ -193,6 +196,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Стандартный отчёт',
 'label.cron_schedule' => 'Расписание cron',
 'label.what_is_it' => 'Что это?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Вход в систему',
@@ -238,6 +244,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Добавление уведомления',
 'title.edit_notification' => 'Редактирование уведомления',
 'title.delete_notification' => 'Удаление уведомления',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Экспортирование данных команды',
 'title.import' => 'Импортирование данных команды',
 'title.options' => 'Опции',

--- a/WEB-INF/resources/ru.lang.php
+++ b/WEB-INF/resources/ru.lang.php
@@ -199,6 +199,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Вход в систему',

--- a/WEB-INF/resources/sk.lang.php
+++ b/WEB-INF/resources/sk.lang.php
@@ -213,6 +213,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Prihlásenie',

--- a/WEB-INF/resources/sk.lang.php
+++ b/WEB-INF/resources/sk.lang.php
@@ -164,6 +164,9 @@ $i18n_key_words = array(
 'label.week_total' => 'Týždeň celkom',
 // TODO: translate the following string.
 // 'label.day_total' => 'Day total',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Dnes',
 'label.total_hours' => 'Hodín celkom',
 'label.total_cost' => 'Náklady celkom',
@@ -207,6 +210,9 @@ $i18n_key_words = array(
 // TODO: translate the following strings.
 // 'label.cron_schedule' => 'Cron schedule',
 // 'label.what_is_it' => 'What is it?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Prihlásenie',
@@ -255,6 +261,7 @@ $i18n_key_words = array(
 // 'title.add_notification' => 'Adding Notification',
 // 'title.edit_notification' => 'Editing Notification',
 // 'title.delete_notification' => 'Deleting Notification',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Exportovanie údajov o tíme',
 'title.import' => 'Importovanie údajov o tíme',
 'title.options' => 'Nastavenia',

--- a/WEB-INF/resources/sr.lang.php
+++ b/WEB-INF/resources/sr.lang.php
@@ -199,6 +199,8 @@ $i18n_key_words = array(
 // 'label.year' => 'Year',
 // 'label.month' => 'Month',
 // 'label.quota' => 'Quota',
+// 'label.dailyWorkingHours' => 'Daily working hours',
+// 'label.empty_values_explanation' => 'If values are empty, quotas are calculated automatically based on holidays in config',
 
 // Form titles.
 'title.login' => 'Prijava',

--- a/WEB-INF/resources/sr.lang.php
+++ b/WEB-INF/resources/sr.lang.php
@@ -153,6 +153,9 @@ $i18n_key_words = array(
 'label.cost' => 'Cena',
 'label.week_total' => 'Zbir časova nedeljno',
 'label.day_total' => 'Zbir časova dnevno',
+// 'label.month_total' => 'Month total',
+// 'label.month_left' => 'Time until quota is met',
+// 'label.month_over' => 'Over monthly quota',
 'label.today' => 'Danas',
 'label.total_hours' => 'Ukupno časova',
 'label.total_cost' => 'Ukupna cena',
@@ -193,6 +196,9 @@ $i18n_key_words = array(
 'label.fav_report' => 'Omiljeni izveštaji',
 'label.cron_schedule' => 'Sredi raspored',
 'label.what_is_it' => 'Šta je ovo?',
+// 'label.year' => 'Year',
+// 'label.month' => 'Month',
+// 'label.quota' => 'Quota',
 
 // Form titles.
 'title.login' => 'Prijava',
@@ -238,6 +244,7 @@ $i18n_key_words = array(
 'title.add_notification' => 'Dodavanje napomene',
 'title.edit_notification' => 'Izmena napomene',
 'title.delete_notification' => 'Brisanje napomene',
+// 'title.monthly_quota' => 'Monthly quota',
 'title.export' => 'Izvoz podataka tim-a',
 'title.import' => 'Uvoz podataka tim-a',
 'title.options' => 'Opcije',

--- a/WEB-INF/templates/cf_monthly_quota.tpl
+++ b/WEB-INF/templates/cf_monthly_quota.tpl
@@ -1,0 +1,43 @@
+{$forms.monthlyQuotaForm.open}
+<table>
+    <tr>
+        <td>{$i18n.label.year}</td>
+        <td>{$forms.monthlyQuotaForm.years.control}</td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <table> 
+            <tr>
+                <td class="tableHeader">{$i18n.label.month}</td>
+                <td class="tableHeader">{$i18n.label.quota}</td>
+            </tr>
+ {foreach $months as $month}
+                <tr>
+                    <td>{$month}</td>
+                    <td>{$forms.monthlyQuotaForm.$month.control}</td>
+                </tr>
+ {/foreach}         
+                <tr>
+                    <td colspan="2" style="text-align:center;">
+                        <input type="submit" value="{$i18n.button.save}">
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+{$forms.monthlyQuotaForm.close}
+<script>
+function yearChange(value){
+    var url = window.location.href;
+    
+    if (url.indexOf('?') > 0){
+        var parameter = url.substring(url.indexOf('?') + 1, url.length);
+        url = url.replace(parameter, 'year=' + value);
+    } else {
+        url = '?year=' + value;
+    }
+    
+    window.location = url;
+}
+</script>

--- a/WEB-INF/templates/cf_monthly_quota.tpl
+++ b/WEB-INF/templates/cf_monthly_quota.tpl
@@ -1,7 +1,22 @@
 {$forms.monthlyQuotaForm.open}
+<div style="padding: 0 0 10 0">
+    <table border="0" class="divider">
+        <tr>
+            <td align="center">
+                <table>
+                    <tr>
+                        <td>{$i18n.label.dailyWorkingHours}</td>
+                        <td>{$forms.monthlyQuotaForm.dailyWorkingHours.control}</td>
+                        <td><input type="submit" name="dailyHours" value="{$i18n.button.save}"></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>        
+    </table>
+</div>
 <table>
     <tr>
-        <td>{$i18n.label.year}</td>
+        <td>{$i18n.label.year}:</td>
         <td>{$forms.monthlyQuotaForm.years.control}</td>
     </tr>
     <tr>
@@ -16,16 +31,17 @@
                     <td>{$month}</td>
                     <td>{$forms.monthlyQuotaForm.$month.control}</td>
                 </tr>
- {/foreach}         
+ {/foreach}     
                 <tr>
                     <td colspan="2" style="text-align:center;">
-                        <input type="submit" value="{$i18n.button.save}">
+                        <input type="submit" name="quotas" value="{$i18n.button.save}*">
                     </td>
                 </tr>
             </table>
         </td>
     </tr>
 </table>
+<div>* - {$i18n.label.empty_values_explanation}</div>
 {$forms.monthlyQuotaForm.close}
 <script>
 function yearChange(value){

--- a/WEB-INF/templates/profile_edit.tpl
+++ b/WEB-INF/templates/profile_edit.tpl
@@ -52,6 +52,15 @@ function handlePluginCheckboxes() {
   } else {
     configureLabel.style.visibility = "hidden";
   }
+  
+  var monthlyQuotaCheckBox = document.getElementById("monthly_quota");
+  configureLabel = document.getElementById("monthly_quota_config");
+  if (monthlyQuotaCheckBox.checked){
+    configureLabel.style.visibility = "visible";
+  } else {
+  configureLabel.style.visibility = "hidden";
+  }
+  
 }
 </script>
 
@@ -181,7 +190,11 @@ function handlePluginCheckboxes() {
           </tr>
           <tr>
             <td align="right" nowrap>{$forms.profileForm.locking.control}</td>
-            <td><label for="notifications">{$i18n.title.locking}</label> <span id="locking_config"><a href="locking.php">{$i18n.label.configure}</a></span></td>
+            <td><label for="locking">{$i18n.title.locking}</label> <span id="locking_config"><a href="locking.php">{$i18n.label.configure}</a></span></td>
+          </tr>
+          <tr>
+            <td align="right" nowrap>{$forms.profileForm.monthly_quota.control}</td>
+            <td><label for="monthly_quota">{$i18n.title.monthly_quota}</label> <span id="monthly_quota_config"><a href="cf_monthly_quota.php">{$i18n.label.configure}</a></span></td>
           </tr>
 {/if}
 

--- a/WEB-INF/templates/reports.tpl
+++ b/WEB-INF/templates/reports.tpl
@@ -149,7 +149,7 @@ function handleCheckboxes() {
 
 {$forms.reportForm.open}
 <div style="padding: 0 0 10 0;">
-  <table border="0" bgcolor="#efefef" width="720">
+  <table border="0" class="divider">
     <tr>
       <td>
         <table cellspacing="1" cellpadding="3" border="0">
@@ -278,7 +278,7 @@ function handleCheckboxes() {
       </table>
 
 <div style="padding: 10 0 10 0;">
-  <table border="0" bgcolor="#efefef" width="720">
+  <table border="0" class="divider">
     <tr>
       <td align="center">
         <table cellspacing="1" cellpadding="3" border="0">

--- a/WEB-INF/templates/time.tpl
+++ b/WEB-INF/templates/time.tpl
@@ -354,6 +354,16 @@ function get_time() {
     <td align="left">{$i18n.label.week_total}: {$week_total}</td>
     <td align="right">{$i18n.label.day_total}: {$day_total}</td>
   </tr>
+  {if $month_total}
+  <tr>
+    <td align="left">{$i18n.label.month_total}: {$month_total}</td>
+    {if $month_left|strpos:'-' === 0}
+    <td align="right">{$i18n.label.month_over}: <span style="color: green;">{$month_left|substr:1}</span></td>
+    {else}
+    <td align="right">{$i18n.label.month_left}: <span style="color: red;">{$month_left}</span></td>
+    {/if}
+  </tr>
+  {/if}
 </table>
 {/if}
 {$forms.timeRecordForm.close}

--- a/cf_monthly_quota.php
+++ b/cf_monthly_quota.php
@@ -30,9 +30,15 @@ $quota = new MonthlyQuota();
 if ($request->isPost()){
   $postedYear = $request->getParameter("years");
   $year = intval($postedYear);
+  $res = false;
   for ($i=0; $i < count($months); $i++){
-    $quota->update($postedYear, $i+1, $request->getParameter($months[$i]));
+    $res = $quota->update($postedYear, $i+1, $request->getParameter($months[$i]));
   }
+  if ($res){
+    header('Location: profile_edit.php');
+    exit();
+  } else
+      $err->add($i18n->getKey('error.db'));
 }
 
 // returns months where January is month 1, not 0

--- a/cf_monthly_quota.php
+++ b/cf_monthly_quota.php
@@ -3,6 +3,7 @@
 require_once('initialize.php');
 require_once('plugins/MonthlyQuota.class.php');
 import('form.Form');
+import('WEB-INF/lib/ttTeamHelper');
 
 // Access check.
 if (!ttAccessCheck(right_manage_team)) {
@@ -10,41 +11,67 @@ if (!ttAccessCheck(right_manage_team)) {
   exit();
 }
 
-$form = new Form('monthlyQuotaForm');
-// months are zero indexed
-$months = $i18n->monthNames;
+// fallback values
+$yearStart = 2010;
+$yearEnd = 2030;
+
+if (defined('MONTHLY_QUOTA_YEARS_START')){
+  $yearStart = (int)MONTHLY_QUOTA_YEARS_START;
+}
+if (defined('MONTHLY_QUOTA_YEARS_END')){
+  $yearEnd = (int)MONTHLY_QUOTA_YEARS_END;
+}
+
+// create values for dropdown
 $years = array();
-for ($i=1990; $i < 2040; $i++) { 
+for ($i=$yearStart; $i < $yearEnd; $i++) { 
   array_push($years, array('id'=>$i, 'name'=>$i));
 }
 
-$year = $request->getParameter("year");
-if (!$year or !ttValidInteger($year)){
-  $year = date("Y");
-}else {
-  $year = intval($year);
+// get selected year from url parameters
+$selectedYear = $request->getParameter("year");
+if (!$selectedYear or !ttValidInteger($selectedYear)){
+  $selectedYear = date("Y");
+} else {
+  $selectedYear = intval($selectedYear);
 }
+
+// months are zero indexed
+$months = $i18n->monthNames;
 
 $quota = new MonthlyQuota();
 
 if ($request->isPost()){
-  $postedYear = $request->getParameter("years");
-  $year = intval($postedYear);
   $res = false;
-  for ($i=0; $i < count($months); $i++){
-    $res = $quota->update($postedYear, $i+1, $request->getParameter($months[$i]));
+  // if user pressed save fpr monthly quotas
+  if ($_POST["quotas"]){
+    $postedYear = $request->getParameter("years");
+    $selectedYear = intval($postedYear);
+    for ($i=0; $i < count($months); $i++){
+      $res = $quota->update($postedYear, $i+1, $request->getParameter($months[$i]));
+    }
   }
-  if ($res){
+  // if user saved required working hours for a day
+  if ($_POST["dailyHours"]){
+    $hours = $request->getParameter("dailyWorkingHours");
+    $teamDetails = ttTeamHelper::getTeamDetails($quota->usersTeamId);
+    $res = ttTeamHelper::update($quota->usersTeamId, array('name'=>$teamDetails['team_name'], 
+                                                           'working_hours'=>$hours));
+  }
+  if ($res) {
     header('Location: profile_edit.php');
     exit();
-  } else
-      $err->add($i18n->getKey('error.db'));
+  } else {
+    $err->add($i18n->getKey('error.db'));
+  }
 }
 
 // returns months where January is month 1, not 0
-$monthsData = $quota->get($year);
+$monthsData = $quota->get($selectedYear);
 
-$form->addInput(array('type'=>'combobox', 'name'=>'years', 'data'=>$years, 'datakeys'=>array('id', 'name'), 'value'=>$year, 'onchange'=>'yearChange(this.value);'));
+$form = new Form('monthlyQuotaForm');
+
+$form->addInput(array('type'=>'combobox', 'name'=>'years', 'data'=>$years, 'datakeys'=>array('id', 'name'), 'value'=>$selectedYear, 'onchange'=>'yearChange(this.value);'));
 for ($i=0; $i < count($months); $i++) { 
   $value = "";
   if (array_key_exists($i+1, $monthsData)){
@@ -53,7 +80,9 @@ for ($i=0; $i < count($months); $i++) {
   $name = $months[$i];
   $form->addInput(array('type'=>'text', 'name'=>$name, 'maxlength'=>3, 'value'=> $value, 'style'=>'width:50px'));
 }
+$form->addInput(array('type'=>'text', 'name'=>'dailyWorkingHours', 'value'=>$quota->getDailyWorkingHours(), 'style'=>'width:50px'));
 $smarty->assign('months', $months);
 $smarty->assign('forms', array($form->getName()=>$form->toArray()));
+$smarty->assign('title', $i18n->getKey('title.monthly_quota'));
 $smarty->assign('content_page_name', 'cf_monthly_quota.tpl');
 $smarty->display('index.tpl');

--- a/cf_monthly_quota.php
+++ b/cf_monthly_quota.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once('initialize.php');
+require_once('plugins/MonthlyQuota.class.php');
+import('form.Form');
+
+// Access check.
+if (!ttAccessCheck(right_manage_team)) {
+  header('Location: access_denied.php');
+  exit();
+}
+
+$form = new Form('monthlyQuotaForm');
+// months are zero indexed
+$months = $i18n->monthNames;
+$years = array();
+for ($i=1990; $i < 2040; $i++) { 
+  array_push($years, array('id'=>$i, 'name'=>$i));
+}
+
+$year = $request->getParameter("year");
+if (!$year or !ttValidInteger($year)){
+  $year = date("Y");
+}else {
+  $year = intval($year);
+}
+
+$quota = new MonthlyQuota();
+
+if ($request->isPost()){
+  $postedYear = $request->getParameter("years");
+  $year = intval($postedYear);
+  for ($i=0; $i < count($months); $i++){
+    $quota->update($postedYear, $i+1, $request->getParameter($months[$i]));
+  }
+}
+
+// returns months where January is month 1, not 0
+$monthsData = $quota->get($year);
+
+$form->addInput(array('type'=>'combobox', 'name'=>'years', 'data'=>$years, 'datakeys'=>array('id', 'name'), 'value'=>$year, 'onchange'=>'yearChange(this.value);'));
+for ($i=0; $i < count($months); $i++) { 
+  $value = "";
+  if (array_key_exists($i+1, $monthsData)){
+    $value = $monthsData[$i+1];
+  }
+  $name = $months[$i];
+  $form->addInput(array('type'=>'text', 'name'=>$name, 'maxlength'=>3, 'value'=> $value, 'style'=>'width:50px'));
+}
+$smarty->assign('months', $months);
+$smarty->assign('forms', array($form->getName()=>$form->toArray()));
+$smarty->assign('content_page_name', 'cf_monthly_quota.tpl');
+$smarty->display('index.tpl');

--- a/dbinstall.php
+++ b/dbinstall.php
@@ -519,6 +519,10 @@ if ($_POST) {
     setChange("ALTER TABLE tt_teams ADD COLUMN lock_spec varchar(255) default NULL");
     setChange("ALTER TABLE tt_teams DROP locktime");
   }
+  
+  if ($_POST["convert1900to1930"]){
+    setChange("CREATE TABLE `timetracker`.`tt_monthly_quota` ( `year` SMALLINT UNSIGNED NOT NULL , `month` TINYINT UNSIGNED NOT NULL , `quota` SMALLINT UNSIGNED NOT NULL , PRIMARY KEY (`year`, `month`))");
+  }
 
   // The update_clients function updates projects field in tt_clients table.
   if ($_POST["update_clients"]) {
@@ -622,7 +626,7 @@ if ($_POST) {
 <h2>DB Install</h2>
 <table width="80%" border="1" cellpadding="10" cellspacing="0">
   <tr>
-    <td width="80%"><b>Create database structure (v1.9)</b>
+    <td width="80%"><b>Create database structure (v1.9.30)</b>
     <br>(applies only to new installations, do not execute when updating)</br></td><td><input type="submit" name="crstructure" value="Create"></td>
   </tr>
 </table>
@@ -656,6 +660,10 @@ if ($_POST) {
   <tr valign="top">
     <td>Update database structure (v1.6 to v1.9)</td>
     <td><input type="submit" name="convert1600to1900" value="Update"><br></td>
+  </tr>
+  <tr valign="top">
+    <td>Update database structure (v1.9 to v1.9.30)</td>
+    <td><input type="submit" name="convert1900to1930" value="Update"><br></td>
   </tr>
 </table>
 

--- a/dbinstall.php
+++ b/dbinstall.php
@@ -521,9 +521,12 @@ if ($_POST) {
   }
   
   if ($_POST["convert1900to1930"]){
-    setChange("CREATE TABLE `timetracker`.`tt_monthly_quota` ( `year` SMALLINT UNSIGNED NOT NULL , `month` TINYINT UNSIGNED NOT NULL , `quota` SMALLINT UNSIGNED NOT NULL , PRIMARY KEY (`year`, `month`))");
+    setChange("CREATE TABLE `tt_monthly_quota` (`team_id` int(11) NOT NULL, `year` smallint(5) UNSIGNED NOT NULL, `month` tinyint(3) UNSIGNED NOT NULL, `quota` smallint(5) UNSIGNED NOT NULL, PRIMARY KEY (`year`,`month`,`team_id`))");
+    setChange("ALTER TABLE `tt_monthly_quota` ADD CONSTRAINT `FK_TT_TEAM_CONSTRAING` FOREIGN KEY (`team_id`) REFERENCES `tt_teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE");
+    setChange("ALTER TABLE `tt_teams` ADD `daily_working_hours` SMALLINT NULL DEFAULT '8' AFTER `lock_spec`");
+    setChange("UPDATE `tt_teams` SET `daily_working_hours` = 8");
   }
-
+  
   // The update_clients function updates projects field in tt_clients table.
   if ($_POST["update_clients"]) {
     $mdb2 = getConnection();
@@ -607,6 +610,7 @@ if ($_POST) {
     setChange("OPTIMIZE TABLE tt_fav_reports");
     setChange("OPTIMIZE TABLE tt_invoices");
     setChange("OPTIMIZE TABLE tt_log");
+    setChange("OPTIMIZE TABLE tt_monthly_quota");
     setChange("OPTIMIZE TABLE tt_project_task_binds");
     setChange("OPTIMIZE TABLE tt_projects");
     setChange("OPTIMIZE TABLE tt_tasks");

--- a/default.css
+++ b/default.css
@@ -117,6 +117,10 @@ select{ font-size: 10pt; font-family: verdana; }
   border-bottom: 1px solid silver;
 }
 
+.borderTop td {
+  border-top: 1px solid silver;
+}
+
 .sectionHeaderNoBorder {
   font-weight: bold;
 }
@@ -129,6 +133,13 @@ select{ font-size: 10pt; font-family: verdana; }
 .info_message {
   font-weight: bold;
   color: #0000c0;
+}
+
+.divider {
+  background-color: #efefef;
+}
+table.divider {
+  width: 720px;
 }
 
 div#LoginAboutText { width:400px; }

--- a/mysql.sql
+++ b/mysql.sql
@@ -338,3 +338,15 @@ create index user_idx on tt_expense_items(user_id);
 create index client_idx on tt_expense_items(client_id);
 create index project_idx on tt_expense_items(project_id);
 create index invoice_idx on tt_expense_items(invoice_id);
+
+#
+# Structure for table tt_monthly_quota.
+# This table lists expense items.
+#
+
+CREATE TABLE `tt_monthly_quota` ( 
+  `year` SMALLINT UNSIGNED NOT NULL ,   # year we'setting monthly quota for
+  `month` TINYINT UNSIGNED NOT NULL ,   # month we're settng monthly quota for
+  `quota` SMALLINT UNSIGNED NOT NULL ,  # the monthly quota
+  PRIMARY KEY (`year`, `month`)
+);

--- a/mysql.sql
+++ b/mysql.sql
@@ -28,6 +28,7 @@ CREATE TABLE `tt_teams` (
   `plugins` varchar(255) default NULL,                   # a list of enabled plugins for team
   `lock_spec` varchar(255) default NULL,                 # Cron specification for record locking,
                                                          # for example: "0 10 * * 1" for "weekly on Mon at 10:00".
+  `daily_working_hours` smallint(6) DEFAULT '8',         # number of working hours per days, a worker is suppose to work
   `custom_logo` tinyint(4) default '0',                  # whether to use a custom logo or not
   `status` tinyint(4) default '1',                       # team status
   PRIMARY KEY (`id`)
@@ -341,12 +342,17 @@ create index invoice_idx on tt_expense_items(invoice_id);
 
 #
 # Structure for table tt_monthly_quota.
-# This table lists expense items.
+# This table lists monthly quota per team.
 #
 
-CREATE TABLE `tt_monthly_quota` ( 
-  `year` SMALLINT UNSIGNED NOT NULL ,   # year we'setting monthly quota for
-  `month` TINYINT UNSIGNED NOT NULL ,   # month we're settng monthly quota for
-  `quota` SMALLINT UNSIGNED NOT NULL ,  # the monthly quota
-  PRIMARY KEY (`year`, `month`)
+CREATE TABLE `tt_monthly_quota` (
+  `team_id` int(11) NOT NULL,             # team's id
+  `year` smallint(5) UNSIGNED NOT NULL,   # year we'setting monthly quota for
+  `month` tinyint(3) UNSIGNED NOT NULL,   # month we're settng monthly quota for
+  `quota` smallint(5) UNSIGNED NOT NULL,  # the monthly quota
+  PRIMARY KEY (`year`,`month`,`team_id`)
 );
+
+ALTER TABLE `tt_monthly_quota`
+  ADD CONSTRAINT `FK_TT_TEAM_CONSTRAING` FOREIGN KEY (`team_id`) REFERENCES `tt_teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/plugins/MonthlyQuota.class.php
+++ b/plugins/MonthlyQuota.class.php
@@ -1,0 +1,141 @@
+<?php
+
+class MonthlyQuota {
+    
+    var $db;
+    var $holidays;
+    // Old style constructors are DEPRECATED in PHP 7.0, and will be removed in a future version. You should always use __construct() in new code.
+    function __construct() {
+        $this->db = getConnection();
+        $i18n = $GLOBALS['I18N'];
+        $this->holidays = $i18n->holidays;
+    }
+    
+    public function update($year, $month, $quota) {
+        $deleteSql = "DELETE FROM tt_monthly_quota WHERE year = $year AND month = $month";
+        $this->db->exec($deleteSql);
+        $insertSql = "INSERT INTO tt_monthly_quota (year, month, quota) values ($year, $month, $quota)";
+        $affected = $this->db->exec($insertSql);
+        return (!is_a($affected, 'PEAR_Error'));
+    }
+        
+    public function get($year, $month) {
+        
+        if (is_null($month)){
+            return $this->getMany($year);
+        }
+        
+        return $this->getSingle($year, $month);
+    }
+    
+    private function getSingle($year, $month) {
+        
+        $sql = "SELECT quota FROM tt_monthly_quota WHERE year = $year AND month = $month";
+        $reader = $this->db->query($sql);
+        if (is_a($reader, 'PEAR_Error')) {
+            return false;
+        }
+        
+        $row = $reader->fetchRow();
+        
+        // if we don't find a record, return calculated monthly quota
+        if (is_null($row)){
+            
+            $holidaysWithYear = array();
+            foreach ($this->holidays as $day) {
+                $parts = explode("/", $day);
+                $holiday = "$year-$parts[0]-$parts[1]";
+                array_push($holidaysWithYear, $holiday);
+            }
+            
+            $daysInMonth = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+            return $this->getWorkingDays("$year-$month-01", "$year-$month-$daysInMonth", $holidaysWithYear) * 8;
+        }
+        
+        return $row["quota"];  
+    }
+    
+    private function getMany($year){
+        $sql = "SELECT year, month, quota FROM tt_monthly_quota WHERE year = $year";
+        $result = array();
+        $res = $this->db->query($sql);
+        if (is_a($res, 'PEAR_Error')) {
+            return false;
+        }
+        
+        while ($val = $res->fetchRow()) {
+            $result[$val["month"]] = $val["quota"];
+            // $result[] = $val;
+        }        
+        
+        return $result;
+    }
+    
+    //The function returns the no. of business days between two dates and it skips the holidays
+    private function getWorkingDays($startDate, $endDate, $holidays) {
+        // do strtotime calculations just once
+        $endDate = strtotime($endDate);
+        $startDate = strtotime($startDate);
+
+        //The total number of days between the two dates. We compute the no. of seconds and divide it to 60*60*24
+        //We add one to inlude both dates in the interval.
+        $days = ($endDate - $startDate) / 86400 + 1;
+
+        $noOfFullWeeks = floor($days / 7);
+        $noOfRemainingDays = fmod($days, 7);
+
+        //It will return 1 if it's Monday,.. ,7 for Sunday
+        $firstDayofWeek = date("N", $startDate);
+        $lastDayofWeek = date("N", $endDate);
+
+        //---->The two can be equal in leap years when february has 29 days, the equal sign is added here
+        //In the first case the whole interval is within a week, in the second case the interval falls in two weeks.
+        if ($firstDayofWeek <= $lastDayofWeek) {
+            if ($firstDayofWeek <= 6 && 6 <= $lastDayofWeek) {
+                $noOfRemainingDays--;                
+            }
+            
+            if ($firstDayofWeek <= 7 && 7 <= $lastDayofWeek) {
+                $noOfRemainingDays--;
+            }
+        }
+        else {
+            // (edit by Tokes to fix an edge case where the start day was a Sunday
+            // and the end day was NOT a Saturday)
+
+            // the day of the week for start is later than the day of the week for end
+            if ($firstDayofWeek == 7) {
+                // if the start date is a Sunday, then we definitely subtract 1 day
+                $noOfRemainingDays--;
+
+                if ($lastDayofWeek == 6) {
+                    // if the end date is a Saturday, then we subtract another day
+                    $noOfRemainingDays--;
+                }
+            }
+            else {
+                // the start date was a Saturday (or earlier), and the end date was (Mon..Fri)
+                // so we skip an entire weekend and subtract 2 days
+                $noOfRemainingDays -= 2;
+            }
+        }
+
+        //T he no. of business days is: (number of weeks between the two dates) * (5 working days) + the remainder
+        // ---->february in none leap years gave a remainder of 0 but still calculated weekends between first and last day, this is one way to fix it
+        $workingDays = $noOfFullWeeks * 5;
+        if ($noOfRemainingDays > 0 ) {
+            $workingDays += $noOfRemainingDays;
+        }
+
+        // We subtract the holidays
+        foreach($holidays as $holiday){
+            $timeStamp = strtotime($holiday);
+            // If the holiday doesn't fall in weekend
+            // TODO: add handling for countries where they move non working day to first working day if holiday is on weekends
+            if ($startDate <= $timeStamp && $timeStamp <= $endDate && date("N", $timeStamp) != 6 && date("N", $timeStamp ) != 7)
+                $workingDays--;
+        }
+
+        return $workingDays;
+    }
+}

--- a/profile_edit.php
+++ b/profile_edit.php
@@ -69,6 +69,7 @@ if ($request->isPost()) {
     $cl_tax_expenses = $request->getParameter('tax_expenses');
     $cl_notifications = $request->getParameter('notifications');
     $cl_locking = $request->getParameter('locking');
+    $cl_monthly_quota = $request->getParameter('monthly_quota');
   }
 } else {
   $cl_name = $user->name;
@@ -92,11 +93,12 @@ if ($request->isPost()) {
     $cl_clients = in_array('cl', $plugins);
     $cl_client_required = in_array('cm', $plugins);
     $cl_invoices = in_array('iv', $plugins);
-    $cl_custom_fields = in_array('cf', $plugins);
+    $cl_custom_fields = in_array('cf', $plugins);    
     $cl_expenses = in_array('ex', $plugins);
     $cl_tax_expenses = in_array('et', $plugins);
     $cl_notifications = in_array('no', $plugins);
     $cl_locking = in_array('lk', $plugins);
+    $cl_monthly_quota = in_array('mq', $plugins);
   }
 }
 
@@ -176,6 +178,7 @@ if ($user->canManageTeam()) {
   $form->addInput(array('type'=>'checkbox','name'=>'tax_expenses','data'=>1,'value'=>$cl_tax_expenses));
   $form->addInput(array('type'=>'checkbox','name'=>'notifications','data'=>1,'value'=>$cl_notifications,'onchange'=>'handlePluginCheckboxes()'));
   $form->addInput(array('type'=>'checkbox','name'=>'locking','data'=>1,'value'=>$cl_locking,'onchange'=>'handlePluginCheckboxes()'));
+  $form->addInput(array('type'=>'checkbox','name'=>'monthly_quota','data'=>1,'value'=>$cl_monthly_quota,'onchange'=>'handlePluginCheckboxes()'));
 }
 $form->addInput(array('type'=>'submit','name'=>'btn_save','value'=>$i18n->getKey('button.save')));
 
@@ -226,6 +229,8 @@ if ($request->isPost()) {
         $plugins .= ',no';
       if ($cl_locking)
         $plugins .= ',lk';
+      if ($cl_monthly_quota)
+        $plugins .= ',mq';
       $plugins = trim($plugins, ',');
 
       $update_result = ttTeamHelper::update($user->team_id, array(

--- a/time.php
+++ b/time.php
@@ -63,6 +63,17 @@ if ($user->isPluginEnabled('cf')) {
   $smarty->assign('custom_fields', $custom_fields);
 }
 
+if ($user->isPluginEnabled('mq')){
+  require_once('plugins/MonthlyQuota.class.php');
+  $quota = new MonthlyQuota();
+  $monthlyQuota = $quota->get($selected_date->mYear, $selected_date->mMonth);
+  $month_total = ttTimeHelper::getTimeForMonth($user->getActiveUser(), $selected_date);
+  $minutesLeft = ttTimeHelper::toMinutes($monthlyQuota) - ttTimeHelper::toMinutes($month_total);
+  
+  $smarty->assign('month_total', $month_total);
+  $smarty->assign('month_left', ttTimeHelper::fromMinutes($minutesLeft));
+}
+
 // Initialize variables.
 $cl_start = trim($request->getParameter('start'));
 $cl_finish = trim($request->getParameter('finish'));


### PR DESCRIPTION
The plugin adds following functionality:

- Team leader can set monthly quota in hours for each month. If no quota is set, one is calculated from working days within a month
- Users than see their monthly sum of hours and how much are they under/over quota. 

Please code review and tell me if anything needs to be changed. I've taken the liberty to call this version 1.9.30 - if you do not like it, please suggest a different version. 

Regards