### PR TITLE
Fix new line symbol on Windows systems in dbinstall.php

### DIFF
--- a/dbinstall.php
+++ b/dbinstall.php
@@ -61,7 +61,7 @@ if ($request->isGet()) {
     // spit white space before output in some situations such as in PDF reports.
     $file = fopen(APP_DIR."/WEB-INF/config.php", "r");
     $line = fgets($file);
-    if (strcmp("<?php\n", $line) !== 0) {
+    if (strcmp("<?php".PHP_EOL, $line) !== 0) {
       echo('<font color="red">Error: WEB-INF/config.php file does not start with PHP opening tag.</font><br>');
     }
     fclose($file);


### PR DESCRIPTION
I wrote a comment about this on commit 5aa9264. 

**Disclaimer!** I have only tested it on my local machine, but it should only affect Windows systems and continue function exactly the same as before on *NIX systems. 
More information about the `PHP_EOL` constant can be found in [this answer on Stack Overflow](http://stackoverflow.com/a/6666554). 