### PR TITLE
Add indicator for uncompleted time entry in users.php

### DIFF
--- a/WEB-INF/resources/en.lang.php
+++ b/WEB-INF/resources/en.lang.php
@@ -352,6 +352,7 @@ $i18n_key_words = array(
 // Users form. See example at https://timetracker.anuko.com/users.php
 'form.users.active_users' => 'Active Users',
 'form.users.inactive_users' => 'Inactive Users',
+'form.users.uncompleted_entry' => 'User has an uncompleted time entry',
 'form.users.role' => 'Role',
 'form.users.manager' => 'Manager',
 'form.users.comanager' => 'Co-manager',

--- a/WEB-INF/resources/sv.lang.php
+++ b/WEB-INF/resources/sv.lang.php
@@ -351,6 +351,7 @@ $i18n_key_words = array(
 // Users form. See example at https://timetracker.anuko.com/users.php
 'form.users.active_users' => 'Aktiva användare',
 'form.users.inactive_users' => 'Inaktiva användare',
+'form.users.uncompleted_entry' => 'Användaren har en oavslutad tidsregistrering',
 'form.users.role' => 'Roll',
 'form.users.manager' => 'Ansvarig',
 'form.users.comanager' => 'Delansvarig',

--- a/WEB-INF/templates/mobile/users.tpl
+++ b/WEB-INF/templates/mobile/users.tpl
@@ -19,6 +19,7 @@
     {foreach $active_users as $u}
         <tr bgcolor="{cycle values="#f5f5f5,#dedee5"}">
           <td>
+						<span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
             {if $user->isManager()}
               <a href="user_edit.php?id={$u.id}">{$u.name|escape:'html'}</a>
             {else}

--- a/WEB-INF/templates/mobile/users.tpl
+++ b/WEB-INF/templates/mobile/users.tpl
@@ -19,7 +19,7 @@
     {foreach $active_users as $u}
         <tr bgcolor="{cycle values="#f5f5f5,#dedee5"}">
           <td>
-						<span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
+            <span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
             {if $user->isManager()}
               <a href="user_edit.php?id={$u.id}">{$u.name|escape:'html'}</a>
             {else}

--- a/WEB-INF/templates/users.tpl
+++ b/WEB-INF/templates/users.tpl
@@ -21,9 +21,9 @@
     {foreach $active_users as $u}
         <tr bgcolor="{cycle values="#f5f5f5,#dedee5"}">
           <td>
-						<span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
-						{$u.name|escape:'html'}
-					</td>
+            <span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
+            {$u.name|escape:'html'}
+          </td>
           <td>{$u.login|escape:'html'}</td>
       {if $smarty.const.ROLE_MANAGER == $u.role}
             <td>{$i18n.form.users.manager}</td>

--- a/WEB-INF/templates/users.tpl
+++ b/WEB-INF/templates/users.tpl
@@ -20,7 +20,10 @@
   {if $active_users}
     {foreach $active_users as $u}
         <tr bgcolor="{cycle values="#f5f5f5,#dedee5"}">
-          <td>{$u.name|escape:'html'}</td>
+          <td>
+						<span class="uncompleted-entry{if $u.has_uncompleted_entry} active{/if}"{if $u.has_uncompleted_entry} title="{$i18n.form.users.uncompleted_entry}"{/if}></span>
+						{$u.name|escape:'html'}
+					</td>
           <td>{$u.login|escape:'html'}</td>
       {if $smarty.const.ROLE_MANAGER == $u.role}
             <td>{$i18n.form.users.manager}</td>

--- a/default.css
+++ b/default.css
@@ -144,6 +144,16 @@ table.divider {
 
 div#LoginAboutText { width:400px; }
 
+.uncompleted-entry {
+	display: inline-block;
+	height: 8px;
+	width: 8px;
+	border: 1px solid rgba(0, 0, 0, .1);
+	border-radius: 50%;
+	background-color: rgba(0, 0, 0, .1);
+}
+.uncompleted-entry.active { background-color: red; }
+
 /* Mobile styles */
 .mobile-table {
   border: 0;

--- a/default.css
+++ b/default.css
@@ -145,12 +145,12 @@ table.divider {
 div#LoginAboutText { width:400px; }
 
 .uncompleted-entry {
-	display: inline-block;
-	height: 8px;
-	width: 8px;
-	border: 1px solid rgba(0, 0, 0, .1);
-	border-radius: 50%;
-	background-color: rgba(0, 0, 0, .1);
+  display: inline-block;
+  height: 8px;
+  width: 8px;
+  border: 1px solid rgba(0, 0, 0, .1);
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, .1);
 }
 .uncompleted-entry.active { background-color: red; }
 

--- a/mobile/users.php
+++ b/mobile/users.php
@@ -29,6 +29,7 @@
 require_once('../initialize.php');
 import('form.Form');
 import('ttTeamHelper');
+import('ttTimeHelper');
 
 // Access check.
 if (!ttAccessCheck(right_data_entry)) {
@@ -41,6 +42,14 @@ $active_users = ttTeamHelper::getActiveUsers(array('getAllFields'=>true));
 if($user->canManageTeam()) {
   $can_delete_manager = (1 == count($active_users));
   $inactive_users = ttTeamHelper::getInactiveUsers($user->team_id, true);
+}
+
+// Check each active user if they have an uncompleted time entry.
+foreach ($active_users as $key => $user) {
+	// Turn value from database into boolean.
+	$has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
+	// Add to current user in $active_users array.
+	$active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
 }
 
 $smarty->assign('active_users', $active_users);

--- a/mobile/users.php
+++ b/mobile/users.php
@@ -46,10 +46,10 @@ if($user->canManageTeam()) {
 
 // Check each active user if they have an uncompleted time entry.
 foreach ($active_users as $key => $user) {
-	// Turn value from database into boolean.
-	$has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
-	// Add to current user in $active_users array.
-	$active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
+  // Turn value from database into boolean.
+  $has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
+  // Add to current user in $active_users array.
+  $active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
 }
 
 $smarty->assign('active_users', $active_users);

--- a/users.php
+++ b/users.php
@@ -46,10 +46,10 @@ if($user->canManageTeam()) {
 
 // Check each active user if they have an uncompleted time entry.
 foreach ($active_users as $key => $user) {
-	// Turn value from database into boolean.
-	$has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
-	// Add to current user in $active_users array.
-	$active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
+  // Turn value from database into boolean.
+  $has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
+  // Add to current user in $active_users array.
+  $active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
 }
 
 $smarty->assign('active_users', $active_users);

--- a/users.php
+++ b/users.php
@@ -29,6 +29,7 @@
 require_once('initialize.php');
 import('form.Form');
 import('ttTeamHelper');
+import('ttTimeHelper');
 
 // Access check.
 if (!ttAccessCheck(right_data_entry)) {
@@ -41,6 +42,14 @@ $active_users = ttTeamHelper::getActiveUsers(array('getAllFields'=>true));
 if($user->canManageTeam()) {
   $can_delete_manager = (1 == count($active_users));
   $inactive_users = ttTeamHelper::getInactiveUsers($user->team_id, true);
+}
+
+// Check each active user if they have an uncompleted time entry.
+foreach ($active_users as $key => $user) {
+	// Turn value from database into boolean.
+	$has_uncompleted_entry = boolval(ttTimeHelper::getUncompleted($user['id']));
+	// Add to current user in $active_users array.
+	$active_users[$key]['has_uncompleted_entry'] = $has_uncompleted_entry;
 }
 
 $smarty->assign('active_users', $active_users);


### PR DESCRIPTION
> Roles that can manage team now see if a user has an uncompleted time entry from the Users screen.

![uncompleted_entries](https://cloud.githubusercontent.com/assets/1066486/18791303/76800754-81b2-11e6-98d9-48c6f9bb57c8.png)

What do you think about this idea? 
This way the manager can get a simple overview over which users are currently working on something. 

Could we do the design any different? Maybe a separate column in the table, with a header?
If you hover over the dot, and it's red, you see the new string I added to the translations. 

How about the technical implementation? Is the logic clean enough?