### PR TITLE
Fix some more deprecation notices on class constructors for PHP 7+

### DIFF
--- a/WEB-INF/lib/ttSysConfig.class.php
+++ b/WEB-INF/lib/ttSysConfig.class.php
@@ -39,7 +39,7 @@ class ttSysConfig {
   var $mdb2 = null;
 
   // Constructor.
-  function ttSysConfig($u_id) {
+  function __construct($u_id) {
     $this->u_id = $u_id;
     $this->mdb2 = getConnection();
   }

--- a/WEB-INF/lib/ttUser.class.php
+++ b/WEB-INF/lib/ttUser.class.php
@@ -54,7 +54,7 @@ class ttUser {
   var $rights = 0;              // A mask of user rights.
 
   // Constructor.
-  function ttUser($login, $id = null) {
+  function __construct($login, $id = null) {
     if (!$login && !$id) {
       // nothing to initialize
       return;

--- a/plugins/CustomFields.class.php
+++ b/plugins/CustomFields.class.php
@@ -37,7 +37,7 @@ class CustomFields {
   var $options = array(); // Array of options for a dropdown custom field.
   
   // Constructor.
-  function CustomFields($team_id) {
+  function __construct($team_id) {
   	$mdb2 = getConnection();
   	
   	// Get fields.


### PR DESCRIPTION
* Modified classes: `ttSysConfig`, `ttUser` and `CustomFields` plugin