### PR TITLE
Update filename for exported reports to the users language

### DIFF
--- a/tofile.php
+++ b/tofile.php
@@ -62,6 +62,9 @@ if ($totals_only)
 else
   $items = ttReportHelper::getItems($bean);
 
+// Build a string to use as filename for the files being downloaded.
+$filename = strtolower($i18n->getKey('title.report')).'_'.$bean->mValues['start_date'].'_'.$bean->mValues['end_date'];
+
 header('Pragma: public'); // This is needed for IE8 to download files over https.
 header('Content-Type: text/html; charset=utf-8');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
@@ -74,7 +77,7 @@ header('Cache-Control: private', false);
 // 1) entries exported to xml
 if ('xml' == $type) {
   header('Content-Type: application/xml');
-  header('Content-Disposition: attachment; filename="timesheet.xml"');
+  header('Content-Disposition: attachment; filename="'.$filename.'.xml"');
 
   print "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   print "<rows>\n";
@@ -141,7 +144,7 @@ if ('xml' == $type) {
 // 2) entries exported to csv
 if ('csv' == $type) {
   header('Content-Type: application/csv');
-  header('Content-Disposition: attachment; filename="timesheet.csv"');
+  header('Content-Disposition: attachment; filename="'.$filename.'.csv"');
 
   // Print UTF8 BOM first to identify encoding.
   $bom = chr(239).chr(187).chr(191); // 0xEF 0xBB 0xBF in the beginning of the file is UTF8 BOM.

--- a/topdf.php
+++ b/topdf.php
@@ -87,6 +87,9 @@ if ($items && 'no_grouping' != $group_by) {
   $cur_grouped_by = '';
 }
 
+// Build a string to use as filename for the files being downloaded.
+$filename = strtolower($i18n->getKey('title.report')).'_'.$bean->mValues['start_date'].'_'.$bean->mValues['end_date'];
+
 // Start preparing HTML to build PDF from.
 $styleHeader = 'style="background-color:#a6ccf7;"';
 $styleSubtotal = 'style="background-color:#e0e0e0;"';
@@ -327,7 +330,7 @@ header('Cache-Control: post-check=0, pre-check=0', false);
 header('Cache-Control: private', false);
 
 header('Content-Type: application/pdf');
-header('Content-Disposition: attachment; filename="timesheet.pdf"');
+header('Content-Disposition: attachment; filename="'.$filename.'.pdf"');
 
 
 // Beginning of TCPDF code here.
@@ -404,6 +407,6 @@ $pdf->writeHTML($html, true, false, false, false, '');
 
 // Close and output PDF document.
 // $pdf->Output('timesheet.pdf', 'I'); // This will display inline in browser.
-$pdf->Output('timesheet.pdf', 'D'); // D is for downloads.
+$pdf->Output($filename.'pdf', 'D'); // D is for downloads.
 
 // End of of TCPDF code.

--- a/topdf.php
+++ b/topdf.php
@@ -407,6 +407,6 @@ $pdf->writeHTML($html, true, false, false, false, '');
 
 // Close and output PDF document.
 // $pdf->Output('timesheet.pdf', 'I'); // This will display inline in browser.
-$pdf->Output($filename.'pdf', 'D'); // D is for downloads.
+$pdf->Output($filename.'.pdf', 'D'); // D is for downloads.
 
 // End of of TCPDF code.


### PR DESCRIPTION
Now defaults to "report" in the users language, or English if the word isn't set, and also includes start date and end date for the generated report. 

{report}_{start_date}_{end_date}.xml/csv/pdf