### PR TITLE
Update the 101% table height to use a fixed scrollbar via CSS

### DIFF
--- a/WEB-INF/templates/header.tpl
+++ b/WEB-INF/templates/header.tpl
@@ -20,10 +20,7 @@
 
 {assign var="tab_width" value="700"}
 
-<!--  101% height here is a workaround for Firefox shifting content horizontally when scrollbar appears / disappears.
-See https://bugzilla.mozilla.org/show_bug.cgi?id=279425.
-With 101% height we essentially force the scrollbar to always appear. -->
-<table height="101%" cellspacing="0" cellpadding="0" width="100%" border="0">
+<table height="100%" cellspacing="0" cellpadding="0" width="100%" border="0">
   <tr>
     <td valign="top" align="center"> <!-- This is to centrally align all our content. -->
 

--- a/default.css
+++ b/default.css
@@ -33,6 +33,10 @@ a:visited { text-decoration: none; }
 
 a:hover { text-decoration: underline; }
 
+html {
+  overflow-y: scroll;
+}
+
 body {
   font-size: 10pt;
   font-family: verdana;


### PR DESCRIPTION
Tested on Windows 10 on latest Chrome, Firefox 43+47+48+49, Internet Explorer 11+10 (and emulated 9+8+7) and Microsoft Edge 38.