### PR TITLE
Report and log management

### DIFF
--- a/WEB-INF/lib/ttClientHelper.class.php
+++ b/WEB-INF/lib/ttClientHelper.class.php
@@ -60,7 +60,7 @@ class ttClientHelper {
     $mdb2 = getConnection();
 
     $sql = "select id, name from tt_clients
-      where team_id = $user->team_id and (status = 0 or status = 1) order by name";
+      where team_id = $user->team_id and (status = 0 or status = 1) order by UPPER(name)";
     $res = $mdb2->query($sql);
     if (!is_a($res, 'PEAR_Error')) {
       while ($val = $res->fetchRow()) {
@@ -286,7 +286,7 @@ class ttClientHelper {
     $sql = "select distinct c.id, c.name, c.projects from tt_user_project_binds upb
       inner join tt_client_project_binds cpb on (cpb.project_id = upb.project_id)
       inner join tt_clients c on (c.id = cpb.client_id and c.status = 1)
-      where upb.user_id = $user_id and upb.status = 1 order by c.name";
+      where upb.user_id = $user_id and upb.status = 1 order by UPPER(c.name)";
 
     $res = $mdb2->query($sql);
     if (!is_a($res, 'PEAR_Error')) {

--- a/WEB-INF/lib/ttExportHelper.class.php
+++ b/WEB-INF/lib/ttExportHelper.class.php
@@ -64,7 +64,8 @@ class ttExportHelper {
     fwrite($file, "<team currency=\"".$user->currency."\" lock_spec=\"".$user->lock_spec."\" lang=\"".$user->lang.
       "\" decimal_mark=\"".$user->decimal_mark."\" date_format=\"".$user->date_format."\" time_format=\"".$user->time_format.
       "\" week_start=\"".$user->week_start."\" workday_hours=\"".$user->workday_hours.
-      "\" plugins=\"".$user->plugins."\" tracking_mode=\"".$user->tracking_mode."\" record_type=\"".$user->record_type."\">\n");
+      "\" plugins=\"".$user->plugins."\" tracking_mode=\"".$user->tracking_mode."\" task_required=\"".$user->task_required.
+      "\" record_type=\"".$user->record_type."\">\n");
     fwrite($file, "  <name><![CDATA[".$user->team."]]></name>\n");
     fwrite($file, "  <address><![CDATA[".$user->address."]]></address>\n");
     fwrite($file, "</team>\n");

--- a/WEB-INF/lib/ttImportHelper.class.php
+++ b/WEB-INF/lib/ttImportHelper.class.php
@@ -127,6 +127,7 @@ class ttImportHelper {
           'week_start' => $this->teamData['WEEK_START'],
           'plugins' => $this->teamData['PLUGINS'],
           'tracking_mode' => $this->teamData['TRACKING_MODE'],
+          'task_required' => $this->teamData['TASK_REQUIRED'],
           'record_type' => $this->teamData['RECORD_TYPE']));
         if ($team_id) {
           $this->team_id = $team_id;

--- a/WEB-INF/lib/ttReportHelper.class.php
+++ b/WEB-INF/lib/ttReportHelper.class.php
@@ -231,8 +231,10 @@ class ttReportHelper {
     array_push($fields, 'l.id as id');
     array_push($fields, '1 as type'); // Type 1 is for tt_log entries.
     array_push($fields, 'l.date as date');
-    if($user->canManageTeam() || $user->isClient())
+	if($user->canManageTeam() || $user->isClient()){
+	  array_push($fields, 'u.id as user_id');
       array_push($fields, 'u.name as user');
+	}
     // Add client name if it is selected.
     if ($bean->getAttribute('chclient') || 'client' == $group_by_option)
       array_push($fields, 'c.name as client');
@@ -279,7 +281,12 @@ class ttReportHelper {
     // Add invoice name if it is selected.
     if (($user->canManageTeam() || $user->isClient()) && $bean->getAttribute('chinvoice'))
       array_push($fields, 'i.name as invoice');
-
+  
+	// Add billable if it is selected.
+  	if ($bean->getAttribute('chbillable')){
+		array_push($fields, 'l.billable as billable');
+	}
+	
     // Prepare sql query part for left joins.
     $left_joins = null;
     if ($bean->getAttribute('chclient') || 'client' == $group_by_option)
@@ -380,7 +387,6 @@ class ttReportHelper {
 
     $sql .= $sort_part;
     // By now we are ready with sql.
-
     // Obtain items for report.
     $res = $mdb2->query($sql);
     if (is_a($res, 'PEAR_Error')) die($res->getMessage());

--- a/WEB-INF/lib/ttReportHelper.class.php
+++ b/WEB-INF/lib/ttReportHelper.class.php
@@ -231,6 +231,7 @@ class ttReportHelper {
     array_push($fields, 'l.id as id');
     array_push($fields, '1 as type'); // Type 1 is for tt_log entries.
     array_push($fields, 'l.date as date');
+	// Add User ID and User Name
 	if($user->canManageTeam() || $user->isClient()){
 	  array_push($fields, 'u.id as user_id');
       array_push($fields, 'u.name as user');

--- a/WEB-INF/lib/ttTeamHelper.class.php
+++ b/WEB-INF/lib/ttTeamHelper.class.php
@@ -709,6 +709,15 @@ class ttTeamHelper {
       $tracking_mode_v = '';
     }
 
+    $task_required = $fields['task_required'];
+    if ($task_required !== null) {
+      $task_required_f = ', task_required';
+      $task_required_v = ', ' . (int)$task_required;
+    } else {
+      $task_required_f = '';
+      $task_required_v = '';
+    }
+
     $record_type = $fields['record_type'];
     if ($record_type !== null) {
       $record_type_f = ', record_type';
@@ -736,11 +745,11 @@ class ttTeamHelper {
       $workday_hours_v = '';
     }
 
-    $sql = "insert into tt_teams (name, address, currency $lockspec_f, lang $decimal_mark_f $date_format_f $time_format_f $week_start_f $plugins_f $tracking_mode_f $record_type_f $uncompleted_indicators_f $workday_hours_f)
+    $sql = "insert into tt_teams (name, address, currency $lockspec_f, lang $decimal_mark_f $date_format_f $time_format_f $week_start_f $plugins_f $tracking_mode_f $task_required_f $record_type_f $uncompleted_indicators_f $workday_hours_f)
       values(".$mdb2->quote(trim($fields['name'])).
       ", ".$mdb2->quote(trim($fields['address'])).
       ", ".$mdb2->quote(trim($fields['currency']))." $lockspec_v, ".$mdb2->quote($lang).
-      "$decimal_mark_v $date_format_v $time_format_v $week_start_v $plugins_v $tracking_mode_v $record_type_v $uncompleted_indicators_v $workday_hours_v)";
+      "$decimal_mark_v $date_format_v $time_format_v $week_start_v $plugins_v $tracking_mode_v $task_required_v $record_type_v $uncompleted_indicators_v $workday_hours_v)";
     $affected = $mdb2->exec($sql);
 
     if (!is_a($affected, 'PEAR_Error')) {

--- a/WEB-INF/lib/ttTeamHelper.class.php
+++ b/WEB-INF/lib/ttTeamHelper.class.php
@@ -395,6 +395,33 @@ class ttTeamHelper {
     }
     return $result;
   }
+  
+    static function getInvoicesByDate($date)
+  {
+    global $user;
+
+    $result = array();
+    $mdb2 = getConnection();
+
+    if (ROLE_CLIENT == $user->role && $user->client_id)
+      $client_part = " and i.client_id = $user->client_id";
+    if(isset($date)){
+        $date_part = ' and DATE_FORMAT(i.date, "%m-%Y") = "' . $date . '"';
+    }
+
+    $sql = "select i.id, i.name, i.date, i.client_id, i.status, c.name as client_name from tt_invoices i
+      left join tt_clients c on (c.id = i.client_id)
+      where i.status = 1 and i.team_id = $user->team_id $client_part $date_part order by i.date asc";
+    $res = $mdb2->query($sql);
+    $result = array();
+    if (!is_a($res, 'PEAR_Error')) {
+      $dt = new DateAndTime(DB_DATEFORMAT);
+      while ($val = $res->fetchRow()) {
+        $result[] = $val;
+      }
+    }
+    return $result;
+  }
 
   // getUserToProjectBinds - obtains all user to project binds for a team.
   static function getUserToProjectBinds($team_id) {

--- a/WEB-INF/lib/ttTeamHelper.class.php
+++ b/WEB-INF/lib/ttTeamHelper.class.php
@@ -764,6 +764,7 @@ class ttTeamHelper {
     $time_format_part = '';
     $week_start_part = '';
     $tracking_mode_part = '';
+    $task_required_part = ' , task_required = '.$mdb2->quote($fields['task_required']);
     $record_type_part = '';
     $uncompleted_indicators_part = '';
     $plugins_part = '';
@@ -785,7 +786,7 @@ class ttTeamHelper {
     if (isset($fields['workday_hours'])) $workday_hours_part = ', workday_hours = '.$mdb2->quote($fields['workday_hours']);
 
     $sql = "update tt_teams set $name_part $addr_part $currency_part $lang_part $decimal_mark_part
-      $date_format_part $time_format_part $week_start_part $tracking_mode_part $record_type_part
+      $date_format_part $time_format_part $week_start_part $tracking_mode_part $task_required_part $record_type_part
       $uncompleted_indicators_part $plugins_part $lock_spec_part $workday_hours_part where id = $team_id";
     $affected = $mdb2->exec($sql);
     if (is_a($affected, 'PEAR_Error')) return false;

--- a/WEB-INF/lib/ttTeamHelper.class.php
+++ b/WEB-INF/lib/ttTeamHelper.class.php
@@ -773,7 +773,7 @@ class ttTeamHelper {
     $time_format_part = '';
     $week_start_part = '';
     $tracking_mode_part = '';
-    $task_required_part = ' , task_required = '.$mdb2->quote($fields['task_required']);
+    $task_required_part = ' , task_required = '.intval($fields['task_required']);
     $record_type_part = '';
     $uncompleted_indicators_part = '';
     $plugins_part = '';

--- a/WEB-INF/lib/ttTimeHelper.class.php
+++ b/WEB-INF/lib/ttTimeHelper.class.php
@@ -95,7 +95,7 @@ class ttTimeHelper {
     if (preg_match('/^([0-1]{0,1}[0-9]|2[0-3])?[.][0-9]{1,4}h?$/', $value )) { // decimal values like 0.5, 1.25h, ... .. 23.9999h
       return true;
     }
-    if (preg_match('/^([0-1]{0,1}[0-9]|2[0-3])?[,][0-9]{1,4}h?$/', $value )) { // decimal values like 0.5, 1.25h, ... .. 23.9999h
+    if (preg_match('/^([0-1]{0,1}[0-9]|2[0-3])?[,][0-9]{1,4}h?$/', $value )) { // decimal values like 0,5, 1,25h, ... .. 23,9999h
       return true;
     }
     return false;

--- a/WEB-INF/lib/ttTimeHelper.class.php
+++ b/WEB-INF/lib/ttTimeHelper.class.php
@@ -95,14 +95,20 @@ class ttTimeHelper {
     if (preg_match('/^([0-1]{0,1}[0-9]|2[0-3])?[.][0-9]{1,4}h?$/', $value )) { // decimal values like 0.5, 1.25h, ... .. 23.9999h
       return true;
     }
-
+    if (preg_match('/^([0-1]{0,1}[0-9]|2[0-3])?[,][0-9]{1,4}h?$/', $value )) { // decimal values like 0.5, 1.25h, ... .. 23.9999h
+      return true;
+    }
     return false;
   }
 
   // normalizeDuration - converts a valid time duration string to format 00:00.
   static function normalizeDuration($value) {
     $time_value = $value;
-
+    
+    // Replace , with .
+    if(strpos($time_value, ",") !== false)
+      $time_value = str_replace (",", ".", $time_value);
+    
     // If we have a decimal format - convert to time format 00:00.
     if((strpos($time_value, '.') !== false) || (strpos($time_value, 'h') !== false)) {
       $val = floatval($time_value);

--- a/WEB-INF/lib/ttUser.class.php
+++ b/WEB-INF/lib/ttUser.class.php
@@ -93,7 +93,7 @@ class ttUser {
       $this->time_format = $val['time_format'];
       $this->week_start = $val['week_start'];
       $this->tracking_mode = $val['tracking_mode'];
-      $this->task_required = intval($val['task_required']);
+      $this->task_required = $val['task_required'];
       $this->record_type = $val['record_type'];
       $this->uncompleted_indicators = $val['uncompleted_indicators'];
       $this->team = $val['team_name'];

--- a/WEB-INF/lib/ttUser.class.php
+++ b/WEB-INF/lib/ttUser.class.php
@@ -42,7 +42,7 @@ class ttUser {
   var $time_format = null;      // Time format.
   var $week_start = 0;          // Week start day.
   var $tracking_mode = 0;       // Tracking mode.
-  var $task_required = null;    // Whether task selection is required on time entires.
+  var $task_required = 0;       // Whether task selection is required on time entires.
   var $record_type = 0;         // Record type (duration vs start and finish, or both).
   var $uncompleted_indicators = 0; // Uncompleted time entry indicators (show nowhere or on users page).
   var $currency = null;         // Currency.
@@ -93,7 +93,7 @@ class ttUser {
       $this->time_format = $val['time_format'];
       $this->week_start = $val['week_start'];
       $this->tracking_mode = $val['tracking_mode'];
-      $this->task_required = $val['task_required'];
+      $this->task_required = intval($val['task_required']);
       $this->record_type = $val['record_type'];
       $this->uncompleted_indicators = $val['uncompleted_indicators'];
       $this->team = $val['team_name'];

--- a/WEB-INF/lib/ttUser.class.php
+++ b/WEB-INF/lib/ttUser.class.php
@@ -42,6 +42,7 @@ class ttUser {
   var $time_format = null;      // Time format.
   var $week_start = 0;          // Week start day.
   var $tracking_mode = 0;       // Tracking mode.
+  var $task_required = null;    // Whether task selection is required on time entires.
   var $record_type = 0;         // Record type (duration vs start and finish, or both).
   var $uncompleted_indicators = 0; // Uncompleted time entry indicators (show nowhere or on users page).
   var $currency = null;         // Currency.
@@ -64,7 +65,7 @@ class ttUser {
 
     $sql = "SELECT u.id, u.login, u.name, u.team_id, u.role, u.client_id, u.email, t.name as team_name, 
       t.address, t.currency, t.lang, t.decimal_mark, t.date_format, t.time_format, t.week_start,
-      t.tracking_mode, t.record_type, t.uncompleted_indicators, t.plugins, t.lock_spec, t.workday_hours, t.custom_logo
+      t.tracking_mode, t.task_required, t.record_type, t.uncompleted_indicators, t.plugins, t.lock_spec, t.workday_hours, t.custom_logo
       FROM tt_users u LEFT JOIN tt_teams t ON (u.team_id = t.id) WHERE ";
     if ($id)
       $sql .= "u.id = $id";
@@ -92,6 +93,7 @@ class ttUser {
       $this->time_format = $val['time_format'];
       $this->week_start = $val['week_start'];
       $this->tracking_mode = $val['tracking_mode'];
+      $this->task_required = $val['task_required'];
       $this->record_type = $val['record_type'];
       $this->uncompleted_indicators = $val['uncompleted_indicators'];
       $this->team = $val['team_name'];

--- a/WEB-INF/resources/.#zh-cn.lang.php
+++ b/WEB-INF/resources/.#zh-cn.lang.php
@@ -1,0 +1,1 @@
+nik@nik-Z97X-SLI.2958

--- a/WEB-INF/resources/.#zh-cn.lang.php
+++ b/WEB-INF/resources/.#zh-cn.lang.php
@@ -1,1 +1,0 @@
-nik@nik-Z97X-SLI.2958

--- a/WEB-INF/resources/de.lang.php
+++ b/WEB-INF/resources/de.lang.php
@@ -121,6 +121,9 @@ $i18n_key_words = array(
 'button.stop' => 'Stop',
 
 // Labels for controls on forms. Labels in this section are used on multiple forms.
+
+'label.billable' => 'Abrechenbar',
+
 'label.team_name' => 'Teamname',
 'label.address' => 'Adresse',
 'label.currency' => 'Währung',
@@ -156,6 +159,7 @@ $i18n_key_words = array(
 'label.week_total' => 'Summe (Woche)',
 // TODO: translate the following.
 // 'label.month_total' => 'Month total',
+'label.month_total' => 'Anzahl Monate(Month_total)',
 'label.today' => 'Heute',
 'label.total_hours' => 'Gesamtstunden',
 'label.total_cost' => 'Totale Kosten',
@@ -169,6 +173,7 @@ $i18n_key_words = array(
 'label.language' => 'Sprache',
 // TODO: translate the following string.
 // 'label.decimal_mark' => 'Decimal mark',
+'label.decimal_mark' => 'Dezimalzeichen',
 'label.date_format' => 'Datumsformat',
 'label.time_format' => 'Zeitformat',
 'label.week_start' => 'Erster Wochentag',
@@ -189,6 +194,7 @@ $i18n_key_words = array(
 'label.role_admin' => '(Administrator)',
 // Translate the following.
 // 'label.page' => 'Page',
+'label.page' => 'Seite',
 // Labels for plugins (extensions to Time Tracker that provide additional features).
 'label.custom_fields' => 'Benutzerfelder',
 // Translate the following.

--- a/WEB-INF/resources/en.lang.php
+++ b/WEB-INF/resources/en.lang.php
@@ -120,6 +120,7 @@ $i18n_key_words = array(
 'button.stop' => 'Stop',
 
 // Labels for controls on forms. Labels in this section are used on multiple forms.
+'label.billable' => 'Billable',
 'label.team_name' => 'Team name',
 'label.address' => 'Address',
 'label.currency' => 'Currency',

--- a/WEB-INF/resources/zh-cn.lang.php
+++ b/WEB-INF/resources/zh-cn.lang.php
@@ -217,15 +217,78 @@ $i18n_key_words = array(
 'label.expense' => 'Expense',
 'label.quantity' => 'Quantity',
 
+// Form titles.
+// TODO: Translate the following.
+// 'title.login' => 'Login',
+// 'title.teams' => 'Teams',
+// 'title.create_team' => 'Creating Team',
+// 'title.edit_team' => 'Editing Team',
+// 'title.delete_team' => 'Deleting Team',
+// 'title.reset_password' => 'Resetting Password',
+// 'title.change_password' => 'Changing Password',
+// 'title.time' => 'Time',
+// 'title.edit_time_record' => 'Editing Time Record',
+// 'title.delete_time_record' => 'Deleting Time Record',
+// 'title.expenses' => 'Expenses',
+// 'title.edit_expense' => 'Editing Expense Item',
+// 'title.delete_expense' => 'Deleting Expense Item',
+// 'title.predefined_expenses' => 'Predefined Expenses',
+// 'title.add_predefined_expense' => 'Adding Predefined Expense',
+// 'title.edit_predefined_expense' => 'Editing Predefined Expense',
+// 'title.delete_predefined_expense' => 'Deleting Predefined Expense',
+// 'title.reports' => 'Reports',
+// 'title.report' => 'Report',
+// 'title.send_report' => 'Sending Report',
+// 'title.invoice' => 'Invoice',
+// 'title.send_invoice' => 'Sending Invoice',
+// 'title.charts' => 'Charts',
+// 'title.projects' => 'Projects',
+// 'title.add_project' => 'Adding Project',
+// 'title.edit_project' => 'Editing Project',
+// 'title.delete_project' => 'Deleting Project',
+// 'title.tasks' => 'Tasks',
+// 'title.add_task' => 'Adding Task',
+// 'title.edit_task' => 'Editing Task',
+// 'title.delete_task' => 'Deleting Task',
+// 'title.users' => 'Users',
+// 'title.add_user' => 'Adding User',
+// 'title.edit_user' => 'Editing User',
+// 'title.delete_user' => 'Deleting User',
+// 'title.clients' => 'Clients',
+// 'title.add_client' => 'Adding Client',
+// 'title.edit_client' => 'Editing Client',
+// 'title.delete_client' => 'Deleting Client',
+// 'title.invoices' => 'Invoices',
+// 'title.add_invoice' => 'Adding Invoice',
+// 'title.view_invoice' => 'Viewing Invoice',
+// 'title.delete_invoice' => 'Deleting Invoice',
+// 'title.notifications' => 'Notifications',
+// 'title.add_notification' => 'Adding Notification',
+// 'title.edit_notification' => 'Editing Notification',
+// 'title.delete_notification' => 'Deleting Notification',
+//  'title.monthly_quotas' => 'Monthly Quotas',
+// 'title.export' => 'Exporting Team Data',
+// 'title.import' => 'Importing Team Data',
+// 'title.options' => 'Options',
+// 'title.profile' => 'Profile',
+// 'title.cf_custom_fields' => 'Custom Fields',
+// 'title.cf_add_custom_field' => 'Adding Custom Field',
+// 'title.cf_edit_custom_field' => 'Editing Custom Field',
+// 'title.cf_delete_custom_field' => 'Deleting Custom Field',
+// 'title.cf_dropdown_options' => 'Dropdown Options',
+// 'title.cf_add_dropdown_option' => 'Adding Option',
+// 'title.cf_edit_dropdown_option' => 'Editing Option',
+// 'title.cf_delete_dropdown_option' => 'Deleting Option',
+// // NOTE TO TRANSLATORS: Locking is a feature to lock records from modifications (ex: weekly on Mondays we lock all previous weeks).
+// // It is also a name for the Locking plugin on the Team profile page.
+// 'title.locking' => 'Locking',
+
+
 
 // TODO: everything below needs serious work and be synchronized with the master English file.
 // For example, form.filter.project property no longer exists, and so on.
 
 // If you intend to improve perhaps go in small steps and coordinate with the maintainer if anything is unclear.
-
-// Form titles.
-// TODO: the entire title section is missing here. See the English file.
-
 "form.filter.project" => '项目',
 "form.filter.filter" => '收藏的报告',
 "form.filter.filter_new" => '保存到我的收藏夹',

--- a/WEB-INF/resources/zh-cn.lang.php
+++ b/WEB-INF/resources/zh-cn.lang.php
@@ -41,101 +41,187 @@ $i18n_key_words = array(
 // Menus.
 'menu.login' => '登录',
 'menu.logout' => '注销',
-// TODO: translate the following:
-// 'menu.forum' => 'Forum',
+'menu.forum' => '论坛',
 'menu.help' => '帮助',
 // Note to translators: menu.create_team needs a more accurate translation.
 'menu.create_team' => '创建新管理账号',
-'menu.profile' => '编辑简介', // TODO: Improve this, used to be "Edit profile", now just "Profile".
-'menu.time' => '我的时间记录', // TODO: Improve this, used to be "My time", now just "Time".
-// TODO: translate the following:
-// 'menu.expenses' => 'Expenses',
+'menu.profile' => '简介',
+'menu.time' => '时间记录',
+'menu.expenses' => '费用',
 'menu.reports' => '报告',
-// TODO: translate the following:
-// 'menu.charts' => 'Charts',
+'menu.charts' => '图表',
 'menu.projects' => '项目',
-// TODO: translate the following:
-// 'menu.tasks' => 'Tasks',
-// 'menu.users' => 'Users',
+'menu.tasks' => '任务',
+'menu.users' => '用户',
 'menu.teams' => '团队',
 'menu.export' => '导出数据',
 'menu.clients' => '客户',
 'menu.options' => '选项',
 
 // Footer - strings on the bottom of most pages.
-// TODO: translate the following:
-// 'footer.contribute_msg' => 'You can contribute to Time Tracker in different ways.',
-// 'footer.credits' => 'Credits',
-// 'footer.license' => 'License',
-// 'footer.improve' => 'Contribute', // Translators: this could mean "Improve", if it makes better sense in your language.
-                                     // This is a link to a webpage that describes how to contribute to the project.
+'footer.contribute_msg' => '你可以以不同的方式为Time Tracker提建议',
+'footer.credits' => '信用',
+'footer.license' => '许可证',
+'footer.improve' => '投稿',
 
 // Error messages.
-// TODO: translate the following:
-// 'error.access_denied' => 'Access denied.',
-// 'error.sys' => 'System error.',
+'error.access_denied' => '拒绝访问',
+'error.sys' => '系统错误',
 'error.db' => '数据库错误',
 'error.field' => '不正确的"{0}"数据',
 'error.empty' => '栏目"{0}"为空',
 'error.not_equal' => '栏目"{0}"不等于栏目"{1}"',
 'error.interval' => '不正确的间隔',
 'error.project' => '选择项目',
-'error.activity' => '选择活动',
+// TODO: translate the following.
+// 'error.task' => 'Select task.',
+// 'error.client' => 'Select client.',
+// 'error.report' => 'Select report.',
 'error.auth' => '不正确的用户名或密码',
 'error.user_exists' => '该用户登录信息已经存在',
 'error.project_exists' => '该项目名称已经存在',
-'error.activity_exists' => '该活动名称已经存在',
-// TODO: translate error.client_exists.
-// 'error.client_exists' => 'client with this name already exists',
+// TODO: translate the following.
+// 'error.task_exists' => 'Task with this name already exists.',
+'error.client_exists' => '具有此名称的客户端已经存在',
+// TODO: translate the following.
+// 'error.invoice_exists' => 'Invoice with this number already exists.',
+// 'error.no_invoiceable_items' => 'There are no invoiceable items.',
 'error.no_login' => '没有该登录信息的用户',
+// TODO: translate the following.
+// 'error.no_teams' => 'Your database is empty. Login as admin and create a new team.',
 'error.upload' => '上传文件出错',
-// TODO: Translate the following:
-// 'error.range_locked' => 'Date range is locked.',
+'error.range_locked' => '日期范围锁定',
 'error.mail_send' => '发送邮件时出错',
-'error.no_email' => '没有电子邮件与该用户名关联',
-// Note to translators: strings below must be translated.
-// 'error.uncompleted_exists' => 'uncompleted entry already exists. close or delete it.',
-// 'error.goto_uncompleted' => 'go to uncompleted entry.',
+'error.no_email' => '没有电子邮件与该用户名关联。',
+'error.uncompleted_exists' => '未完成的条目已经存在。关闭或删除。',
+'error.goto_uncompleted' => '进入未完成的条目。',
+// TODO: translate the following.
+// 'error.overlap' => 'Time interval overlaps with existing records.',
+// 'error.future_date' => 'Date is in future.',
 
-// labels for various buttons
+// Labels for buttons.
 'button.login' => '登录',
 'button.now' => '当前时间',
-// 'button.set' => '设置',
 'button.save' => '保存',
-'button.delete' => '删除',
+// TODO: translate the following.
+// 'button.copy' => 'Copy',
 'button.cancel' => '取消',
 'button.submit' => '提交',
+
+
 // TODO: check / improve translation of all button.add... strings.
+// Concern is that it used to be "add new something", now just "add something".
 'button.add_user' => '添加新用户',
 'button.add_project' => '添加新项目',
-'button.add_activity' => '添加新活动',
+// TODO: translate the following.
+// 'button.add_task' => 'Add task',
 'button.add_client' => '添加新客户',
+// TODO: translate the following.
+// 'button.add_invoice' => 'Add invoice',
+// 'button.add_option' => 'Add option',
 'button.add' => '添加',
 'button.generate' => '创建',
-// Note to translators: button.reset_password needs to be translated.
-// "button.reset_password" => 'reset password',
+'button.reset_password' => '重置密码',
 'button.send' => '发送',
 'button.send_by_email' => '通过邮件发送',
-'button.save_as_new' => '另存为',
-// TODO: improve translation of button.create_team
+// TODO: improve translation of button.create_team (used to be "Create new team", now just "Create team").
 'button.create_team' => '创建新团队',
 'button.export' => '导出团队信息',
 'button.import' => '导入团队信息',
-'button.apply' => '应用',
+// TODO: translate the following.
+// 'button.close' => 'Close',
+// 'button.stop' => 'Stop',
 
-// labels for controls on various forms
-// TODO: translate label.team_name
-// 'label.team_name' => 'team name',
+// Labels for controls on forms. Labels in this section are used on multiple forms.
+'label.team_name' => '团队名称',
+// TODO: translate the following.
+// 'label.address' => 'Address',
 'label.currency' => '货币',
-// TODO: translate label.manager_name and label.manager_login.
-// 'label.manager_name' => 'manager name',
-// 'label.manager_login' => 'manager login',
+'label.manager_name' => '管理员姓名',
+'label.manager_login' => '管理员登录',
+// TODO: translate the following.
+// 'label.person_name' => 'Name',
+// 'label.thing_name' => 'Name',
+// 'label.login' => 'Login',
 'label.password' => '密码',
 'label.confirm_password' => '确认密码',
 'label.email' => '电子邮件',
+// Translate the following.
+// 'label.date' => 'Date',
+// 'label.start_date' => 'Start date',
+// 'label.end_date' => 'End date',
+// 'label.user' => 'User',
+// 'label.users' => 'Users',
+// 'label.client' => 'Client',
+// 'label.clients' => 'Clients',
+// 'label.option' => 'Option',
+// 'label.invoice' => 'Invoice',
+// 'label.project' => 'Project',
+// 'label.projects' => 'Projects',
+// 'label.task' => 'Task',
+// 'label.tasks' => 'Tasks',
+// 'label.description' => 'Description',
+// 'label.start' => 'Start',
+// 'label.finish' => 'Finish',
+// 'label.duration' => 'Duration',
+// 'label.note' => 'Note',
+// 'label.item' => 'Item',
+// 'label.cost' => 'Cost',
+// 'label.day_total' => 'Day total',
+// 'label.week_total' => 'Week total',
+// 'label.month_total' => 'Month total',
+// 'label.today' => 'Today',
+// 'label.total_hours' => 'Total hours',
+// 'label.total_cost' => 'Total cost',
+// 'label.view' => 'View',
+// 'label.edit' => 'Edit',
+'label.delete' => '删除',
+// TODO: Translate the following.
+// 'label.configure' => 'Configure',
+// 'label.select_all' => 'Select all',
+// 'label.select_none' => 'Deselect all',
+// 'label.id' => 'ID',
+// 'label.language' => 'Language',
+// 'label.decimal_mark' => 'Decimal mark',
+// 'label.date_format' => 'Date format',
+// 'label.time_format' => 'Time format',
+// 'label.week_start' => 'First day of week',
+// 'label.comment' => 'Comment',
+// 'label.status' => 'Status',
+// 'label.tax' => 'Tax',
+// 'label.subtotal' => 'Subtotal',
 'label.total' => '总计',
-// Translate the following string.
-// 'label.page' => 'Page',
+// TODO: Translate the following.
+// 'label.client_name' => 'Client name',
+// 'label.client_address' => 'Client address',
+// 'label.or' => 'or',
+// 'label.error' => 'Error',
+// 'label.ldap_hint' => 'Type your <b>Windows login</b> and <b>password</b> in the fields below.',
+// 'label.required_fields' => '* - required fields',
+// 'label.on_behalf' => 'on behalf of',
+// 'label.role_manager' => '(manager)',
+// 'label.role_comanager' => '(co-manager)',
+// 'label.role_admin' => '(administrator)',
+'label.page' => '页码',
+// Labels for plugins (extensions to Time Tracker that provide additional features).
+// TODO: Translate the following.
+'label.custom_fields' => 'Custom fields',
+'label.monthly_quotas' => 'Monthly quotas',
+'label.type' => 'Type',
+'label.type_dropdown' => 'dropdown',
+'label.type_text' => 'text',
+'label.required' => 'Required',
+'label.fav_report' => 'Favorite report',
+'label.cron_schedule' => 'Cron schedule',
+'label.what_is_it' => 'What is it?',
+'label.expense' => 'Expense',
+'label.quantity' => 'Quantity',
+
+
+// TODO: everything below needs serious work and be synchronized with the master English file.
+// For example, form.filter.project property no longer exists, and so on.
+
+// If you intend to improve perhaps go in small steps and coordinate with the maintainer if anything is unclear.
 
 // Form titles.
 // TODO: the entire title section is missing here. See the English file.
@@ -297,7 +383,7 @@ $i18n_key_words = array(
 "form.mail.comment" => '留言',
 "form.mail.above" => '通过电子邮件发送该报告',
 // Note to translators: this string needs to be translated.
-// "form.mail.footer_str" => 'Anuko Time Tracker is a simple, easy to use, open source<br>time tracking system. Visit <a href="https://www.anuko.com">www.anuko.com</a> for more information.',
+ "form.mail.footer_str" => 'anuko时间跟踪器是一种简单、易用、开放源码的时间跟踪系统。 看<a href ="https://www.anuko.com"> www.anuko网</a>更多信息。',
 "form.mail.sending_str" => '<b>消息已发送</b>',
 
 // invoice attributes
@@ -405,9 +491,9 @@ $i18n_key_words = array(
 "label.errors" => '错误',
 "label.ldap_hint" => '在下面的栏目输入您的<b>Windows用户名</b>和<b>密码</b>。',
 // Note to translators: strings below must be translated.
-// "label.calendar_today" => 'today',
-// "label.calendar_close" => 'close',
+ "label.calendar_today" => '今天',
+ "label.calendar_close" => '关闭',
 
 // login hello text
-// "login.hello.text" => "Anuko Time Tracker is a simple, easy to use, open source time tracking system.",
+ "login.hello.text" => "anuko时间跟踪器是一种简单、易用、开放源代码的实时跟踪系统。",
 );

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3633 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3634 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3630 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3631 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3634 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3635 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3631 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3632 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.10.42.3628 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3629 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3629 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3630 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.43.3632 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3633 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/footer.tpl
+++ b/WEB-INF/templates/footer.tpl
@@ -12,7 +12,7 @@
       <br>
       <table cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr>
-          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3635 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
+          <td align="center">&nbsp;Anuko Time Tracker 1.11.44.3636 | Copyright &copy; <a href="https://www.anuko.com/lp/tt_3.htm" target="_blank">Anuko</a> |
             <a href="https://www.anuko.com/lp/tt_4.htm" target="_blank">{$i18n.footer.credits}</a> |
             <a href="https://www.anuko.com/lp/tt_5.htm" target="_blank">{$i18n.footer.license}</a> |
             <a href="https://www.anuko.com/lp/tt_7.htm" target="_blank">{$i18n.footer.improve}</a>

--- a/WEB-INF/templates/invoices.tpl
+++ b/WEB-INF/templates/invoices.tpl
@@ -1,7 +1,18 @@
 <script>
   function chLocation(newLocation) { document.location = newLocation; }
 </script>
-
+{$forms.invoicesForm.open}
+<div>
+  <table>
+    <tr>
+      <td>Rechnungen für Monat</td>
+      <td>{$forms.invoicesForm.date.control}</td>
+    </tr>
+  </table>
+  
+  {$forms.invoicesForm.btn_submit.control}
+</div>
+          
 <table cellspacing="0" cellpadding="7" border="0" width="720">
   <tr>
     <td valign="top">

--- a/WEB-INF/templates/profile_edit.tpl
+++ b/WEB-INF/templates/profile_edit.tpl
@@ -1,4 +1,19 @@
 <script>
+// handleTaskRequiredCheckbox - controls visibility of the Task Required checkbox.
+function handleTaskRequiredCheckbox() {
+  var taskRequiredCheckbox = document.getElementById("task_required");
+  var taskRequiredLabel = document.getElementById("task_required_label");
+  var trackingModeDropdown = document.getElementById("tracking_mode");
+  if (trackingModeDropdown.value == 2) {
+    taskRequiredCheckbox.style.visibility = "visible";
+    taskRequiredLabel.style.visibility = "visible";
+  } else {
+    taskRequiredCheckbox.style.visibility = "hidden";
+    taskRequiredLabel.style.visibility = "hidden";
+  }
+}
+
+
 // handleControls - controls visibility of controls.
 function handlePluginCheckboxes() {
   var clientsCheckbox = document.getElementById("clients");
@@ -139,7 +154,7 @@ function handlePluginCheckboxes() {
           </tr>
           <tr>
             <td align="right" nowrap>{$i18n.form.profile.tracking_mode}:</td>
-            <td>{$forms.profileForm.tracking_mode.control}</td>
+            <td>{$forms.profileForm.tracking_mode.control} {$forms.profileForm.task_required.control} <span id="task_required_label"><label for="task_required">{$i18n.label.required}</label></span></td></td>
           </tr>
           <tr>
             <td align="right" nowrap>{$i18n.form.profile.record_type}:</td>

--- a/WEB-INF/templates/profile_edit.tpl
+++ b/WEB-INF/templates/profile_edit.tpl
@@ -19,7 +19,7 @@ function handlePluginCheckboxes() {
   var clientsCheckbox = document.getElementById("clients");
   var invoicesCheckbox = document.getElementById("invoices");
   var requiredCheckbox = document.getElementById("client_required");
-  var requiredLabel = document.getElementById("required_label");
+  var requiredLabel = document.getElementById("client_required_label");
   if (clientsCheckbox.checked) {
     requiredCheckbox.style.visibility = "visible";
     requiredLabel.style.visibility = "visible";
@@ -194,7 +194,7 @@ function handlePluginCheckboxes() {
           </tr>
           <tr>
             <td align="right" nowrap>{$forms.profileForm.clients.control}</td>
-            <td><label for="clients">{$i18n.title.clients}</label> {$forms.profileForm.client_required.control} <span id="required_label"><label for="client_required">{$i18n.label.required}</label></span></td>
+            <td><label for="clients">{$i18n.title.clients}</label> {$forms.profileForm.client_required.control} <span id="client_required_label"><label for="client_required">{$i18n.label.required}</label></span></td>
           </tr>
           <tr>
             <td align="right" nowrap>{$forms.profileForm.invoices.control}</td>

--- a/WEB-INF/templates/report.tpl
+++ b/WEB-INF/templates/report.tpl
@@ -78,7 +78,7 @@
         {if $report_row_class == 'rowReportItem'} {$report_row_class = 'rowReportItemAlt'} {else} {$report_row_class = 'rowReportItem'} {/if}
       {/if}
       <tr class="{$report_row_class}">
-        <td class="cellLeftAligned"><a href="time_edit.php?id={$item.id}&user_id={$item.user_id}" title="Edit">{$item.date}</a></td>
+        <td class="cellLeftAligned"><a href="time_edit.php?id={$item.id}&user_id={$item.user_id}&source=report" title="Edit">{$item.date}</a></td>
     {if $user->canManageTeam() || $user->isClient()}<td class="cellLeftAligned">{$item.user|escape}</td>{/if}
     {if $bean->getAttribute('chclient')}<td class="cellLeftAligned">{$item.client|escape}</td>{/if}
     {if $bean->getAttribute('chproject')}<td class="cellLeftAligned">{$item.project|escape}</td>{/if}

--- a/WEB-INF/templates/report.tpl
+++ b/WEB-INF/templates/report.tpl
@@ -47,6 +47,7 @@
   {if $bean->getAttribute('chnote')}<td class="tableHeader">{$i18n.label.note}</td>{/if}
   {if $bean->getAttribute('chcost')}<td class="tableHeaderCentered" width="5%">{$i18n.label.cost}</td>{/if}
   {if $bean->getAttribute('chinvoice')}<td class="tableHeader">{$i18n.label.invoice}</td>{/if}
+  {if $bean->getAttribute('chbillable')}<td class="tableHeader">{$i18n.label.billable}</td>{/if}
       </tr>
   {foreach $report_items as $item}
     <!-- print subtotal for a block of grouped values -->
@@ -77,7 +78,7 @@
         {if $report_row_class == 'rowReportItem'} {$report_row_class = 'rowReportItemAlt'} {else} {$report_row_class = 'rowReportItem'} {/if}
       {/if}
       <tr class="{$report_row_class}">
-        <td class="cellLeftAligned">{$item.date}</td>
+        <td class="cellLeftAligned"><a href="time_edit.php?id={$item.id}&user_id={$item.user_id}" title="Edit">{$item.date}</a></td>
     {if $user->canManageTeam() || $user->isClient()}<td class="cellLeftAligned">{$item.user|escape}</td>{/if}
     {if $bean->getAttribute('chclient')}<td class="cellLeftAligned">{$item.client|escape}</td>{/if}
     {if $bean->getAttribute('chproject')}<td class="cellLeftAligned">{$item.project|escape}</td>{/if}
@@ -95,6 +96,7 @@
         {if 2 == $item.type}<td bgcolor="white"><input type="checkbox" name="item_id_{$item.id}"></td>{/if}
       {/if}
     {/if}
+	{if $bean->getAttribute('chbillable')}<td class="cellLeftAligned">{$item.billable|escape}</td>{/if}
       </tr>
     {$prev_date = $item.date}
     {if $print_subtotals} {$prev_grouped_by = $item.grouped_by} {/if}
@@ -131,6 +133,7 @@
     {if $bean->getAttribute('chnote')}<td></td>{/if}
     {if $bean->getAttribute('chcost')}<td nowrap class="cellRightAlignedSubtotal">{$user->currency|escape} {if $user->canManageTeam() || $user->isClient()}{$totals['cost']}{else}{$totals['expenses']}{/if}</td>{/if}
     {if $bean->getAttribute('chinvoice')}<td></td>{/if}
+    {if $bean->getAttribute('chbillable')}<td></td>{/if}
       </tr>
 {/if}
     </table>

--- a/WEB-INF/templates/report.tpl
+++ b/WEB-INF/templates/report.tpl
@@ -78,8 +78,8 @@
         {if $report_row_class == 'rowReportItem'} {$report_row_class = 'rowReportItemAlt'} {else} {$report_row_class = 'rowReportItem'} {/if}
       {/if}
       <tr class="{$report_row_class}">
-        <td class="cellLeftAligned"><a href="time_edit.php?id={$item.id}&user_id={$item.user_id}&source=report" title="Edit">{$item.date}</a></td>
-    {if $user->canManageTeam() || $user->isClient()}<td class="cellLeftAligned">{$item.user|escape}</td>{/if}
+        <td class="cellLeftAligned">{$item.date}</td>
+    {if $user->canManageTeam() || $user->isClient()}<td class="cellLeftAligned"><a href="time_edit.php?id={$item.id}&user_id={$item.user_id}&source=report" title="Edit">{$item.user|escape}</a></td>{/if}
     {if $bean->getAttribute('chclient')}<td class="cellLeftAligned">{$item.client|escape}</td>{/if}
     {if $bean->getAttribute('chproject')}<td class="cellLeftAligned">{$item.project|escape}</td>{/if}
     {if $bean->getAttribute('chtask')}<td class="cellLeftAligned">{$item.task|escape}</td>{/if}

--- a/WEB-INF/templates/report.tpl
+++ b/WEB-INF/templates/report.tpl
@@ -96,7 +96,7 @@
         {if 2 == $item.type}<td bgcolor="white"><input type="checkbox" name="item_id_{$item.id}"></td>{/if}
       {/if}
     {/if}
-	{if $bean->getAttribute('chbillable')}<td class="cellLeftAligned">{$item.billable|escape}</td>{/if}
+	{if $bean->getAttribute('chbillable')}<td class="cellLeftAligned">{$item.billable}</td>{/if}
       </tr>
     {$prev_date = $item.date}
     {if $print_subtotals} {$prev_grouped_by = $item.grouped_by} {/if}

--- a/WEB-INF/templates/reports.tpl
+++ b/WEB-INF/templates/reports.tpl
@@ -241,9 +241,9 @@ function handleCheckboxes() {
   {if $user->isPluginEnabled('cl')}
                 <td width="25%"><label>{$forms.reportForm.chclient.control}&nbsp;{$i18n.label.client}</label></td>
   {/if}
-  {if ($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv')}
+  {if $user->isPluginEnabled('iv')}
                 <td width="25%"><label>{$forms.reportForm.chinvoice.control}&nbsp;{$i18n.label.invoice}</label></td>	
-				<td width="25%"><label>{$forms.reportForm.chbillable.control}&nbsp;{$i18n.label.billable}</label></td>
+		<td width="25%"><label>{$forms.reportForm.chbillable.control}&nbsp;{$i18n.label.billable}</label></td>
               </tr>
   {/if}
 {/if}

--- a/WEB-INF/templates/reports.tpl
+++ b/WEB-INF/templates/reports.tpl
@@ -242,9 +242,10 @@ function handleCheckboxes() {
                 <td width="25%"><label>{$forms.reportForm.chclient.control}&nbsp;{$i18n.label.client}</label></td>
   {/if}
   {if ($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv')}
-                <td width="25%"><label>{$forms.reportForm.chinvoice.control}&nbsp;{$i18n.label.invoice}</label></td>
-  {/if}
+                <td width="25%"><label>{$forms.reportForm.chinvoice.control}&nbsp;{$i18n.label.invoice}</label></td>	
+				<td width="25%"><label>{$forms.reportForm.chbillable.control}&nbsp;{$i18n.label.billable}</label></td>
               </tr>
+  {/if}
 {/if}
               <tr>
                 <td width="25%">{if ($smarty.const.MODE_PROJECTS == $user->tracking_mode || $smarty.const.MODE_PROJECTS_AND_TASKS == $user->tracking_mode)}<label>{$forms.reportForm.chproject.control}&nbsp;{$i18n.label.project}</label>{/if}</td>

--- a/WEB-INF/templates/time_script.tpl
+++ b/WEB-INF/templates/time_script.tpl
@@ -143,6 +143,11 @@ function fillTaskDropdown(id) {
         }
       }
     }
+
+    // Select a task if user is required to do so and there is only one task available.
+    if ({$user->task_required} && dropdown.options.length == 2) { // 2 because of mandatory top option.
+      dropdown.options[1].selected = true;
+    }
   }
 }
 

--- a/dbinstall.php
+++ b/dbinstall.php
@@ -636,7 +636,7 @@ if ($_POST) {
     setChange("ALTER TABLE tt_expense_items modify `name` text NOT NULL");
     setChange("ALTER TABLE `tt_teams` ADD `uncompleted_indicators` SMALLINT(2) NOT NULL DEFAULT '0' AFTER `record_type`");
     setChange("CREATE TABLE `tt_predefined_expenses` (`id` int(11) NOT NULL auto_increment, `team_id` int(11) NOT NULL, `name` varchar(255) NOT NULL, `cost` decimal(10,2) default '0.00', PRIMARY KEY  (`id`))");
-    setChange("ALTER TABLE `tt_teams` ADD `tracking_mode_options` smallint(2) default NULL AFTER `tracking_mode`");
+    setChange("ALTER TABLE `tt_teams` ADD `task_required` smallint(2) default NULL AFTER `tracking_mode`");
   }
   
   // The update_clients function updates projects field in tt_clients table.

--- a/dbinstall.php
+++ b/dbinstall.php
@@ -636,7 +636,7 @@ if ($_POST) {
     setChange("ALTER TABLE tt_expense_items modify `name` text NOT NULL");
     setChange("ALTER TABLE `tt_teams` ADD `uncompleted_indicators` SMALLINT(2) NOT NULL DEFAULT '0' AFTER `record_type`");
     setChange("CREATE TABLE `tt_predefined_expenses` (`id` int(11) NOT NULL auto_increment, `team_id` int(11) NOT NULL, `name` varchar(255) NOT NULL, `cost` decimal(10,2) default '0.00', PRIMARY KEY  (`id`))");
-    setChange("ALTER TABLE `tt_teams` ADD `task_required` smallint(2) default NULL AFTER `tracking_mode`");
+    setChange("ALTER TABLE `tt_teams` ADD `task_required` smallint(2) NOT NULL DEFAULT '0' AFTER `tracking_mode`");
   }
   
   // The update_clients function updates projects field in tt_clients table.

--- a/invoices.php
+++ b/invoices.php
@@ -35,10 +35,31 @@ if (!ttAccessCheck(right_view_invoices) || !$user->isPluginEnabled('iv')) {
   header('Location: access_denied.php');
   exit();
 }
-
-$invoices = ttTeamHelper::getActiveInvoices();
+$form = new Form('invoicesForm');
+$form->addInput(array('type'=>'submit','name'=>'btn_submit','value'=>$i18n->getKey('button.submit')));
+$form->addInput(array('type'=>'datefield','maxlength'=>'20','name'=>'date'));
+//$form->addInput(array('type'=>'datefield','maxlength'=>'20','name'=>'end_date'));
+        
+// Submit.
+if ($request->isPost()) {
+  if ($request->getParameter('btn_submit')) {
+      $date_array = split("-", $request->getParameter('date'));
+      // $date should be m-Y -> 06-2017
+      if ((int)$date_array[1] <= 12 && (int)$date_array[1] >= 1 && (int)$date_array[0] <= 3000 && (int)$date_array[0] >= 2000){
+	$invoices = ttTeamHelper::getInvoicesByDate($date_array[1]."-".$date_array[0]);
+      } else {
+	print_r("ERROR! Date-Format wrong?");
+	$invoices = ttTeamHelper::getActiveInvoices();
+      }
+      $form->setValueByElement("date", $request->getParameter('date'));
+  }
+} else {
+  $form->setValueByElement("date", date("Y-m"));
+  $invoices = ttTeamHelper::getActiveInvoices();
+}
 
 $smarty->assign('invoices', $invoices);
 $smarty->assign('title', $i18n->getKey('title.invoices'));
+$smarty->assign('forms', array($form->getName()=>$form->toArray()));
 $smarty->assign('content_page_name', 'invoices.tpl');
 $smarty->display('index.tpl');

--- a/invoices.php
+++ b/invoices.php
@@ -48,7 +48,6 @@ if ($request->isPost()) {
       if ((int)$date_array[1] <= 12 && (int)$date_array[1] >= 1 && (int)$date_array[0] <= 3000 && (int)$date_array[0] >= 2000){
 	$invoices = ttTeamHelper::getInvoicesByDate($date_array[1]."-".$date_array[0]);
       } else {
-	print_r("ERROR! Date-Format wrong?");
 	$invoices = ttTeamHelper::getActiveInvoices();
       }
       $form->setValueByElement("date", $request->getParameter('date'));

--- a/mobile/time.php
+++ b/mobile/time.php
@@ -196,6 +196,9 @@ if ($request->isPost()) {
     if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode) {
       if (!$cl_project) $err->add($i18n->getKey('error.project'));
     }
+    if (MODE_PROJECTS_AND_TASKS == $user->tracking_mode && $user->task_required) {
+      if (!$cl_task) $err->add($i18n->getKey('error.task'));
+    }
     if (strlen($cl_duration) == 0) {
       if ($cl_start || $cl_finish) {
         if (!ttTimeHelper::isValidTime($cl_start))

--- a/mobile/time_edit.php
+++ b/mobile/time_edit.php
@@ -218,6 +218,9 @@ if ($request->isPost()) {
   if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode) {
     if (!$cl_project) $err->add($i18n->getKey('error.project'));
   }
+  if (MODE_PROJECTS_AND_TASKS == $user->tracking_mode && $user->task_required) {
+    if (!$cl_task) $err->add($i18n->getKey('error.task'));
+  }
   if (!$cl_duration) {
     if ('0' == $cl_duration)
       $err->add($i18n->getKey('error.field'), $i18n->getKey('label.duration'));

--- a/mysql.sql
+++ b/mysql.sql
@@ -24,7 +24,7 @@ CREATE TABLE `tt_teams` (
   `time_format` varchar(20) NOT NULL default '%H:%M',        # time format
   `week_start` smallint(2) NOT NULL DEFAULT '0',             # Week start day, 0 == Sunday.
   `tracking_mode` smallint(2) NOT NULL DEFAULT '1',          # tracking mode ("time", "projects" or "projects and tasks")
-  `tracking_mode_options` smallint(2) default NULL,          # whether a task selection is required or optional
+  `task_required` smallint(2) default NULL,                  # whether a task selection is required or optional
   `record_type` smallint(2) NOT NULL DEFAULT '0',            # time record type ("start and finish", "duration", or both)
   `uncompleted_indicators` smallint(2) NOT NULL DEFAULT '0', # whether to show indicators for users with uncompleted time entries
   `plugins` varchar(255) default NULL,                       # a list of enabled plugins for team

--- a/mysql.sql
+++ b/mysql.sql
@@ -24,7 +24,7 @@ CREATE TABLE `tt_teams` (
   `time_format` varchar(20) NOT NULL default '%H:%M',        # time format
   `week_start` smallint(2) NOT NULL DEFAULT '0',             # Week start day, 0 == Sunday.
   `tracking_mode` smallint(2) NOT NULL DEFAULT '1',          # tracking mode ("time", "projects" or "projects and tasks")
-  `task_required` smallint(2) default NULL,                  # whether a task selection is required or optional
+  `task_required` smallint(2) NOT NULL DEFAULT '0',          # whether a task selection is required or optional
   `record_type` smallint(2) NOT NULL DEFAULT '0',            # time record type ("start and finish", "duration", or both)
   `uncompleted_indicators` smallint(2) NOT NULL DEFAULT '0', # whether to show indicators for users with uncompleted time entries
   `plugins` varchar(255) default NULL,                       # a list of enabled plugins for team

--- a/profile_edit.php
+++ b/profile_edit.php
@@ -87,7 +87,7 @@ if ($request->isPost()) {
     $cl_custom_format_time = $user->time_format;
     $cl_start_week = $user->week_start;
     $cl_tracking_mode = $user->tracking_mode;
-    $cl_ttask_required = $user->task_required;
+    $cl_task_required = $user->task_required;
     $cl_record_type = $user->record_type;
     $cl_uncompleted_indicators = $user->uncompleted_indicators;
 
@@ -163,7 +163,8 @@ if ($user->canManageTeam()) {
   $tracking_mode_options[MODE_TIME] = $i18n->getKey('form.profile.mode_time');
   $tracking_mode_options[MODE_PROJECTS] = $i18n->getKey('form.profile.mode_projects');
   $tracking_mode_options[MODE_PROJECTS_AND_TASKS] = $i18n->getKey('form.profile.mode_projects_and_tasks');
-  $form->addInput(array('type'=>'combobox','name'=>'tracking_mode','style'=>'width: 150px;','data'=>$tracking_mode_options,'value'=>$cl_tracking_mode));
+  $form->addInput(array('type'=>'combobox','name'=>'tracking_mode','style'=>'width: 150px;','data'=>$tracking_mode_options,'value'=>$cl_tracking_mode,'onchange'=>'handleTaskRequiredCheckbox()'));
+  $form->addInput(array('type'=>'checkbox','name'=>'task_required','value'=>$cl_task_required));
 
   // Prepare record type choices.
   $record_type_options = array();
@@ -253,6 +254,7 @@ if ($request->isPost()) {
         'time_format' => $cl_custom_format_time,
         'week_start' => $cl_start_week,
         'tracking_mode' => $cl_tracking_mode,
+        'task_required' => $cl_task_required,
         'record_type' => $cl_record_type,
         'uncompleted_indicators' => $cl_uncompleted_indicators,
         'plugins' => $plugins));
@@ -275,7 +277,7 @@ if ($request->isPost()) {
 
 $smarty->assign('auth_external', $auth->isPasswordExternal());
 $smarty->assign('forms', array($form->getName()=>$form->toArray()));
-$smarty->assign('onload', 'onLoad="handlePluginCheckboxes()"');
+$smarty->assign('onload', 'onLoad="handleTaskRequiredCheckbox(); handlePluginCheckboxes();"');
 $smarty->assign('title', $i18n->getKey('title.profile'));
 $smarty->assign('content_page_name', 'profile_edit.tpl');
 $smarty->display('index.tpl');

--- a/profile_edit.php
+++ b/profile_edit.php
@@ -59,6 +59,7 @@ if ($request->isPost()) {
     $cl_custom_format_time = $request->getParameter('format_time');
     $cl_start_week = $request->getParameter('start_week');
     $cl_tracking_mode = $request->getParameter('tracking_mode');
+    $cl_task_required = $request->getParameter('task_required');
     $cl_record_type = $request->getParameter('record_type');
     $cl_uncompleted_indicators = $request->getParameter('uncompleted_indicators');
     $cl_charts = $request->getParameter('charts');
@@ -86,6 +87,7 @@ if ($request->isPost()) {
     $cl_custom_format_time = $user->time_format;
     $cl_start_week = $user->week_start;
     $cl_tracking_mode = $user->tracking_mode;
+    $cl_ttask_required = $user->task_required;
     $cl_record_type = $user->record_type;
     $cl_uncompleted_indicators = $user->uncompleted_indicators;
 

--- a/reports.php
+++ b/reports.php
@@ -173,9 +173,10 @@ $form->addInput(array('type'=>'datefield','maxlength'=>'20','name'=>'end_date'))
 // Add checkboxes for fields.
 if ($user->isPluginEnabled('cl'))
   $form->addInput(array('type'=>'checkbox','name'=>'chclient'));
-if (($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv'))
+ //Add Invoice and Billable Checkbox if Invoices-Plugin is anabled
+if ($user->isPluginEnabled('iv'))
   $form->addInput(array('type'=>'checkbox','name'=>'chinvoice'));
-if (($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv'))
+if ($user->isPluginEnabled('iv'))
   $form->addInput(array('type'=>'checkbox','name'=>'chbillable'));
 if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode)
   $form->addInput(array('type'=>'checkbox','name'=>'chproject'));

--- a/reports.php
+++ b/reports.php
@@ -175,6 +175,8 @@ if ($user->isPluginEnabled('cl'))
   $form->addInput(array('type'=>'checkbox','name'=>'chclient'));
 if (($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv'))
   $form->addInput(array('type'=>'checkbox','name'=>'chinvoice'));
+if (($user->canManageTeam() || $user->isClient()) && $user->isPluginEnabled('iv'))
+  $form->addInput(array('type'=>'checkbox','name'=>'chbillable'));
 if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode)
   $form->addInput(array('type'=>'checkbox','name'=>'chproject'));
 if (MODE_PROJECTS_AND_TASKS == $user->tracking_mode)

--- a/time.php
+++ b/time.php
@@ -231,6 +231,9 @@ if ($request->isPost()) {
     if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode) {
       if (!$cl_project) $err->add($i18n->getKey('error.project'));
     }
+    if (MODE_PROJECTS_AND_TASKS == $user->tracking_mode && $user->task_required) {
+      if (!$cl_task) $err->add($i18n->getKey('error.task'));
+    }
     if (strlen($cl_duration) == 0) {
       if ($cl_start || $cl_finish) {
         if (!ttTimeHelper::isValidTime($cl_start))

--- a/time.php
+++ b/time.php
@@ -80,6 +80,7 @@ $cl_start = trim($request->getParameter('start'));
 $cl_finish = trim($request->getParameter('finish'));
 $cl_duration = trim($request->getParameter('duration'));
 $cl_note = trim($request->getParameter('note'));
+
 // Custom field.
 $cl_cf_1 = trim($request->getParameter('cf_1', ($request->getMethod()=='POST'? null : @$_SESSION['cf_1'])));
 $_SESSION['cf_1'] = $cl_cf_1;

--- a/time_edit.php
+++ b/time_edit.php
@@ -219,6 +219,9 @@ if ($request->isPost()) {
   if (MODE_PROJECTS == $user->tracking_mode || MODE_PROJECTS_AND_TASKS == $user->tracking_mode) {
     if (!$cl_project) $err->add($i18n->getKey('error.project'));
   }
+  if (MODE_PROJECTS_AND_TASKS == $user->tracking_mode && $user->task_required) {
+    if (!$cl_task) $err->add($i18n->getKey('error.task'));
+  }
   if (!$cl_duration) {
     if ('0' == $cl_duration)
       $err->add($i18n->getKey('error.field'), $i18n->getKey('label.duration'));

--- a/time_edit.php
+++ b/time_edit.php
@@ -51,23 +51,23 @@ $cl_id = $request->getParameter('id');
 
 // report.php sends user_id per get
 // set active user to sent id
-// forward to page with change active user if $_GET["user_id"] is set (meh)
-if( is_numeric($request->getParameter('user_id'))){
-	$on_behalf_id = $request->getParameter('user_id');
-	if(ttUserHelper::getUserName($on_behalf_id)){
-		if($user->canManageTeam()) {
-		  $user->behalf_id = $on_behalf_id;
-		  unset($_SESSION['behalf_id']);
-		  unset($_SESSION['behalf_name']);
+// forward to page with change active user if $_GET["user_id"] is set (there has to be a better way)
 
-		  if($on_behalf_id != $user->id) {
-			$_SESSION['behalf_id'] = $on_behalf_id;
-			$_SESSION['behalf_name'] = ttUserHelper::getUserName($on_behalf_id);
-		  }
-		  header('Location: time_edit.php?id=' .$cl_id . '&source=report');
-		  exit();
-		}
-	}
+$on_behalf_id = $request->getParameter('user_id');
+if (is_numeric($on_behalf_id)){
+  // change user only if logged in user can manage the team
+  if(ttUserHelper::getUserName($on_behalf_id) && $user->canManageTeam()){
+    $user->behalf_id = $on_behalf_id;
+    unset($_SESSION['behalf_id']);
+    unset($_SESSION['behalf_name']);
+
+    if($on_behalf_id != $user->id) {
+	  $_SESSION['behalf_id'] = $on_behalf_id;
+	  $_SESSION['behalf_name'] = ttUserHelper::getUserName($on_behalf_id);
+    }
+    header('Location: time_edit.php?id=' .$cl_id . '&source=report');
+    exit();
+  }
 }
 
 // Get the time record we are editing.

--- a/time_edit.php
+++ b/time_edit.php
@@ -49,6 +49,27 @@ if ($user->isPluginEnabled('cf')) {
 
 $cl_id = $request->getParameter('id');
 
+// report.php sends user_id per get
+// set active user to sent id
+// forward to page with change active user if $_GET["user_id"] is set (meh)
+if( is_numeric($request->getParameter('user_id'))){
+	$on_behalf_id = $request->getParameter('user_id');
+	if(ttUserHelper::getUserName($on_behalf_id)){
+		if($user->canManageTeam()) {
+		  $user->behalf_id = $on_behalf_id;
+		  unset($_SESSION['behalf_id']);
+		  unset($_SESSION['behalf_name']);
+
+		  if($on_behalf_id != $user->id) {
+			$_SESSION['behalf_id'] = $on_behalf_id;
+			$_SESSION['behalf_name'] = ttUserHelper::getUserName($on_behalf_id);
+		  }
+		  header('Location: time_edit.php?id=' .$cl_id . '&source=report');
+		  exit();
+		}
+	}
+}
+
 // Get the time record we are editing.
 $time_rec = ttTimeHelper::getRecord($cl_id, $user->getActiveUser());
 
@@ -318,7 +339,13 @@ if ($request->isPost()) {
       }
       if ($res)
       {
-        header('Location: time.php?date='.$new_date->toString(DB_DATEFORMAT));
+		// $request is set to POST 
+		// for now using $_GET
+		if ($_GET["source"] == "report"){
+			header('Location: report.php');
+		} else {
+			header('Location: time.php?date='.$new_date->toString(DB_DATEFORMAT));
+		}
         exit();
       }
     }

--- a/tofile.php
+++ b/tofile.php
@@ -133,6 +133,7 @@ if ('xml' == $type) {
         print "]]></cost>\n";
       }
       if ($bean->getAttribute('chinvoice')) print "\t<invoice><![CDATA[".$item['invoice']."]]></invoice>\n";
+      if ($bean->getAttribute('chbillable')) print "\t<billable><![CDATA[".$item['billable']."]]></billable>\n";
 
       print "</row>\n";
     }
@@ -199,6 +200,7 @@ if ('csv' == $type) {
     if ($bean->getAttribute('chnote')) print ',"'.$i18n->getKey('label.note').'"';
     if ($bean->getAttribute('chcost')) print ',"'.$i18n->getKey('label.cost').'"';
     if ($bean->getAttribute('chinvoice')) print ',"'.$i18n->getKey('label.invoice').'"';
+    if ($bean->getAttribute('chbillable')) print ',"'.$i18n->getKey('label.billable').'"';
     print "\n";
 
     // Print items.
@@ -225,6 +227,7 @@ if ('csv' == $type) {
           print ',"'.$item['expense'].'"';
       }
       if ($bean->getAttribute('chinvoice')) print ',"'.str_replace('"','""',$item['invoice']).'"';
+	  if ($bean->getAttribute('chbillable')) print ',"'.$item['billable'].'"';
       print "\n";
     }
   }

--- a/topdf.php
+++ b/topdf.php
@@ -91,14 +91,25 @@ if ($items && 'no_grouping' != $group_by) {
 $filename = strtolower($i18n->getKey('title.report')).'_'.$bean->mValues['start_date'].'_'.$bean->mValues['end_date'];
 
 // Start preparing HTML to build PDF from.
-$styleHeader = 'style="background-color:#a6ccf7;"';
-$styleSubtotal = 'style="background-color:#e0e0e0;"';
-$styleCentered = 'style="text-align:center;"';
-$styleRightAligned = 'style="text-align:right;"';
+$styleHeader = 'class="header"';
+$styleSubtotal = 'class="subtotal"';
+$styleCentered = 'class="centered"';
+$styleRightAligned = 'class="rightAligned"';
+$styleWider = 'class="wider"';
+$styleThinner = 'class="thinner"';
 
 $title = $i18n->getKey('title.report').": ".$totals['start_date']." - ".$totals['end_date'];
-$html = '<h1 style="text-align:center;">'.$title.'</h1>';
-$html .= '<table border="1" cellpadding="3" cellspacing="0" width="100%">';
+$html = "<style>"
+	. ".header { background-color:#a6ccf7; } "
+	. ".subtotal { background-color:#e0e0e0; }"
+	. ".centered { text-align:center; }"
+	. ".rightAligned { text-align:right; }"
+	. ".thinner { width: 40px;}"
+	. ".wider { width: 180px;}"
+	. "table { width: 780px; }"
+	. "</style>";
+$html .= '<h1 style="text-align:center;">'.$title.'</h1>';
+$html .= '<table border="1" cellpadding="3" cellspacing="0">';
 
 if ($totals_only) {
   // We are building a "totals only" report with only subtotals and total.
@@ -154,12 +165,13 @@ if ($totals_only) {
   if ($bean->getAttribute('chproject')) { $colspan++; $html .= '<td>'.$i18n->getKey('label.project').'</td>'; }
   if ($bean->getAttribute('chtask')) { $colspan++; $html .= '<td>'.$i18n->getKey('label.task').'</td>'; }
   if ($bean->getAttribute('chcf_1')) { $colspan++; $html .= '<td>'.htmlspecialchars($custom_fields->fields[0]['label']).'</td>'; }
-  if ($bean->getAttribute('chstart')) { $colspan++; $html .= "<td $styleCentered>".$i18n->getKey('label.start').'</td>'; }
-  if ($bean->getAttribute('chfinish')) { $colspan++; $html .= "<td $styleCentered>".$i18n->getKey('label.finish').'</td>'; }
-  if ($bean->getAttribute('chduration')) { $colspan++; $html .= "<td $styleCentered>".$i18n->getKey('label.duration').'</td>'; }
-  if ($bean->getAttribute('chnote')) { $colspan++; $html .= '<td>'.$i18n->getKey('label.note').'</td>'; }
+  if ($bean->getAttribute('chstart')) { $colspan++; $html .= "<td $styleCentered $styleThinner>".$i18n->getKey('label.start').'</td>'; }
+  if ($bean->getAttribute('chfinish')) { $colspan++; $html .= "<td $styleCentered $styleThinner>".$i18n->getKey('label.finish').'</td>'; }
+  if ($bean->getAttribute('chduration')) { $colspan++; $html .= "<td $styleCentered $styleThinner>".$i18n->getKey('label.duration').'</td>'; }
+  if ($bean->getAttribute('chnote')) { $colspan++; $html .= "<td $styleWider>".$i18n->getKey('label.note').'</td>'; }
   if ($bean->getAttribute('chcost')) { $colspan++; $html .= "<td $styleCentered>".$i18n->getKey('label.cost').'</td>'; }
   if ($bean->getAttribute('chinvoice')) { $colspan++; $html .= '<td>'.$i18n->getKey('label.invoice').'</td>'; }
+  if ($bean->getAttribute('chbillable')) { $colspan++; $html .= '<td>'.$i18n->getKey('label.billable').'</td>'; }
   $html .= '</tr>';
   $html .= '</thead>';
 
@@ -209,6 +221,7 @@ if ($totals_only) {
           $html .= '</td>';
         }
         if ($bean->getAttribute('chinvoice')) $html .= '<td></td>';
+        if ($bean->getAttribute('chbillable')) $html .= '<td></td>';
         $html .= '</tr>';
         $html .= '<tr><td colspan="'.$colspan.'">&nbsp;</td></tr>';
       }
@@ -223,10 +236,10 @@ if ($totals_only) {
     if ($bean->getAttribute('chproject')) $html .= '<td>'.htmlspecialchars($item['project']).'</td>';
     if ($bean->getAttribute('chtask')) $html .= '<td>'.htmlspecialchars($item['task']).'</td>';
     if ($bean->getAttribute('chcf_1')) $html .= '<td>'.htmlspecialchars($item['cf_1']).'</td>';
-    if ($bean->getAttribute('chstart')) $html .= "<td $styleRightAligned>".$item['start'].'</td>';
-    if ($bean->getAttribute('chfinish')) $html .= "<td $styleRightAligned>".$item['finish'].'</td>';
-    if ($bean->getAttribute('chduration')) $html .= "<td $styleRightAligned>".$item['duration'].'</td>';
-    if ($bean->getAttribute('chnote')) $html .= '<td>'.htmlspecialchars($item['note']).'</td>';
+    if ($bean->getAttribute('chstart')) $html .= "<td $styleRightAligned $styleThinner>".$item['start'].'</td>';
+    if ($bean->getAttribute('chfinish')) $html .= "<td $styleRightAligned $styleThinner>".$item['finish'].'</td>';
+    if ($bean->getAttribute('chduration')) $html .= "<td $styleRightAligned $styleThinner>".$item['duration'].'</td>';
+    if ($bean->getAttribute('chnote')) $html .= "<td $styleWider>".htmlspecialchars($item['note']).'</td>';
     if ($bean->getAttribute('chcost')) {
       $html .= "<td $styleRightAligned>";
       if ($user->canManageTeam() || $user->isClient())
@@ -236,6 +249,7 @@ if ($totals_only) {
       $html .= '</td>';
     }
     if ($bean->getAttribute('chinvoice')) $html .= '<td>'.htmlspecialchars($item['invoice']).'</td>';
+    if ($bean->getAttribute('chbillable')) $html .= '<td>'.htmlspecialchars($item['billable']).'</td>';
     $html .= '</tr>';
 
     $prev_date = $item['date'];
@@ -284,6 +298,7 @@ if ($totals_only) {
       $html .= '</td>';
     }
     if ($bean->getAttribute('chinvoice')) $html .= '<td></td>';
+    if ($bean->getAttribute('chbillable')) $html .= '<td></td>';
     $html .= '</tr>';
   }
 


### PR DESCRIPTION
Hi,
I made some change which might be usefull for the current version. A lot of my changes are for our custom usage and not perfectly implemented. It's kinda my first time using github this way and i also only started using it halfway through. 

My main changes are in the report and log management. I added an option to edit log entries by clicking on the username seen in the report view. After saving changes you will be sent back to report.php. 
We have a team of 5 people who put all there times and infos in but not all of it is actually relevant. So someone has to go over a month worth of information and put some structure into it. By adding a way to edit the log entries on the report page everything gets easier and faster. This might be helpful for other people but you could probably ignore it.

In addition i am replacing commas by dots on the time entry page. The german/european [num block]((https://images-na.ssl-images-amazon.com/images/I/613%2B8sL%2By4L._SL1100_.jpg)) uses a comma insted of a point. 

Another minor problem was fixed by adding upper(clientname) in an sql statement to make it the same as the other usage. 

I also only worked on the german and english translation files.
The favReports still have to be adjusted to the changes i did by adding billable as an option.


