### PR TITLE
Replace cal_days_in_month with generic date call

### DIFF
--- a/plugins/MonthlyQuota.class.php
+++ b/plugins/MonthlyQuota.class.php
@@ -133,7 +133,7 @@ class MonthlyQuota {
   // getNumWorkdays returns a number of work days in a given month.
   private function getNumWorkdays($month, $year) {
 
-    $daysInMonth = cal_days_in_month(CAL_GREGORIAN, $month, $year); // Number of calendar days in month.
+    $daysInMonth = date('t', mktime(0, 0, 0, $month, 1, $year));
 
     $workdaysInMonth = 0;
     // Iterate through the entire month.


### PR DESCRIPTION
cal_days_in_month relies on PHP being compiled with calendars support.  The date code I replaced it with does not.
This is important because the php:7.2-apache docker image was not built with calendars support and therefore causes timetracker to crash on time.php when quotas are enabled.