### PR TITLE
Remove unnecessary things from html head template

### DIFF
--- a/WEB-INF/templates/header.tpl
+++ b/WEB-INF/templates/header.tpl
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html lang="{constant('LANG_DEFAULT')}">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset={constant('CHARSET')}">
+  <meta charset="{constant('CHARSET')}">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-  <link href="{constant('DEFAULT_CSS')}" rel="stylesheet" type="text/css">
+  <link href="{constant('DEFAULT_CSS')}" rel="stylesheet">
 {if $i18n.language.rtl}
-  <link href="{constant('RTL_CSS')}" rel="stylesheet" type="text/css">
+  <link href="{constant('RTL_CSS')}" rel="stylesheet">
 {/if}
 {if $user->getCustomCss()}
-  <link href="custom_css.php" rel="stylesheet" type="text/css">
+  <link href="custom_css.php" rel="stylesheet">
 {/if}
   <title>Time Tracker{if $title} - {$title}{/if}</title>
   <script src="js/strftime.js"></script>

--- a/WEB-INF/templates/header2.tpl
+++ b/WEB-INF/templates/header2.tpl
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html>
+<html lang="{constant('LANG_DEFAULT')}">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset={constant('CHARSET')}">
+  <meta charset="{constant('CHARSET')}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-  <link href="{constant('DEFAULT_CSS')}" rel="stylesheet" type="text/css">
+  <link href="{constant('DEFAULT_CSS')}" rel="stylesheet">
 {if $i18n.language.rtl}
-  <link href="{constant('RTL_CSS')}" rel="stylesheet" type="text/css">
+  <link href="{constant('RTL_CSS')}" rel="stylesheet">
 {/if}
 {if $user->getCustomCss()}
-  <link href="custom_css.php" rel="stylesheet" type="text/css">
+  <link href="custom_css.php" rel="stylesheet">
 {/if}
   <title>Time Tracker{if $title} - {$title}{/if}</title>
   <script src="js/strftime.js"></script>


### PR DESCRIPTION
* It is recommended to set the `lang` attribute on the HTML tag: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
* Since HTML5, the declaration of charset can be much shorter: https://www.w3.org/International/questions/qa-html-encoding-declarations
* It is now recommended to not define a `type` when declaring `rel="stylesheet"`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type