### PR TITLE
Optimized dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
     # Use localhost:8080 to connect to timetracker via browser.
     ports:
      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   # anuko_db is a mariadb instance to which timetracker connects.
   # Connect parameters are also specified in timetracker dockerfile after

--- a/dockerfile-db
+++ b/dockerfile-db
@@ -1,5 +1,5 @@
 # This file is for development work. Not suitable for production.
-FROM mariadb:latest
+FROM mariadb:10.8
 
 # Copy database creation script.
 COPY mysql.sql /docker-entrypoint-initdb.d/

--- a/dockerfile-tt
+++ b/dockerfile-tt
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libldap2-dev && \
   rm -rf /var/lib/apt/lists/*
     
-  
+# Configure and install php extensions.
 RUN docker-php-ext-configure gd --with-freetype \
  && docker-php-ext-install gd \
     ldap \

--- a/dockerfile-tt
+++ b/dockerfile-tt
@@ -1,6 +1,7 @@
 # This file is for development work. Not suitable for production.
 FROM php:8.1-apache
 
+# Arguments for user and group modification. Needed for file permissions.
 ARG USER_NAME=www-data
 ARG USER_GROUP=www-data
 ARG USER_ID=1000
@@ -32,9 +33,9 @@ RUN pecl install xdebug  \
 # Copy xdebug config.
 COPY xdebug.ini /usr/local/etc/php/conf.d/
 
-# Change www-data users uid and www-data groups gid
+# Change www-data users uid and www-data groups gid.
 RUN usermod  --uid $USER_ID $USER_NAME && groupmod --gid $GROUP_ID $USER_GROUP
 
-# set default user and working directory
+# Set default user and working directory.
 USER www-data
 WORKDIR /var/www/project

--- a/dockerfile-tt
+++ b/dockerfile-tt
@@ -1,5 +1,10 @@
 # This file is for development work. Not suitable for production.
-FROM php:7.2-apache
+FROM php:8.1-apache
+
+ARG USER_NAME=www-data
+ARG USER_GROUP=www-data
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 # Use the default production configuration.
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
@@ -13,22 +18,23 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libfreetype6-dev \
   libldap2-dev && \
   rm -rf /var/lib/apt/lists/*
+    
   
-# Configure php extensions
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ \
+RUN docker-php-ext-configure gd --with-freetype \
  && docker-php-ext-install gd \
-  ldap \
-  mysqli
- 
-# Copy application source code to /var/www/html/.
-COPY . /var/www/html/
+    ldap \
+    mysqli
 
-# Create configuration file.
-RUN cp /var/www/html/WEB-INF/config.php.dist /var/www/html/WEB-INF/config.php
+# Install xdebug.
+RUN pecl install xdebug  \
+    && docker-php-ext-enable xdebug
 
-# Replace DSN value to something connectable to a Docker container running mariadb.
-RUN sed -i "s|mysqli://root:no@localhost/dbname|mysqli://anuko_user:anuko_pw@anuko_db/timetracker|g" /var/www/html/WEB-INF/config.php
-# Note that db is defined as anuko_db/timetracker where anuko_db is service name and timetracker is db name.
-# See docker-compose.yml for details.
+# Copy xdebug config.
+COPY xdebug.ini /usr/local/etc/php/conf.d/
 
-RUN chown -R www-data /var/www/html/
+# Change www-data users uid and www-data groups gid
+RUN usermod  --uid $USER_ID $USER_NAME && groupmod --gid $GROUP_ID $USER_GROUP
+
+# set default user and working directory
+USER www-data
+WORKDIR /var/www/project

--- a/dockerfile-tt
+++ b/dockerfile-tt
@@ -7,30 +7,25 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Override with custom settings.
 # COPY config/php_tt.ini $PHP_INI_DIR/conf.d/
 
-# Install mysqli extension.
-RUN docker-php-ext-install mysqli
-
-# Install gd extension.
-RUN apt-get update && apt-get install libpng-dev libfreetype6-dev -y \
- && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ \
- && docker-php-ext-install gd 
-
-# Install ldap extension.
-RUN apt-get install libldap2-dev -y \
-  && docker-php-ext-install ldap
-# TODO: check if ldap works, as the above is missing this step:
-# && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
-
-# Cleanup. The intention was to keep image size down.
-# RUN rm -rf /var/lib/apt/lists/*
-#
-# The above does not work. Files are removed, but
-# image files (zipped or not) are not getting smaller. Why?
-
+# Install php extensions.
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  libpng-dev \
+  libfreetype6-dev \
+  libldap2-dev && \
+  rm -rf /var/lib/apt/lists/*
+  
+# Configure php extensions
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ \
+ && docker-php-ext-install gd \
+  ldap \
+  mysqli
+ 
 # Copy application source code to /var/www/html/.
 COPY . /var/www/html/
+
 # Create configuration file.
 RUN cp /var/www/html/WEB-INF/config.php.dist /var/www/html/WEB-INF/config.php
+
 # Replace DSN value to something connectable to a Docker container running mariadb.
 RUN sed -i "s|mysqli://root:no@localhost/dbname|mysqli://anuko_user:anuko_pw@anuko_db/timetracker|g" /var/www/html/WEB-INF/config.php
 # Note that db is defined as anuko_db/timetracker where anuko_db is service name and timetracker is db name.

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,6 @@
+[XDebug]
+xdebug.mode=debug
+xdebug.client_host = host.docker.internal
+
+# Enable for automatic connection. This is useful for CLI debugging.
+#xdebug.start_with_request=yes


### PR DESCRIPTION
Based on https://github.com/anuko/timetracker/pull/127:

> * Install all application dependencies in the same block
> 
>     * Add --no-install-recommends switch to reduce image size
> 
>     * Install all PHP extensions in the same block
> 
>     * Add version to DB base image to fix Dockerfilelint issue

Additional changes:
- Removed the copyiny of files to /var/www/html.  Added a volume instead. This volumes syncs local files with files in docker container.
- Added the xdebug extension.
- Switched docker php version to 8.1.